### PR TITLE
Introduce new combinator "foreach" to run actions on the wrapped value

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ case the _std::optional_ does not contain a _person_ it simply returns an empty 
 It's also possible to use the non-member overload for _bind_, but at the call site the user has to wrap the member
 function inside a lambda, which adds a little bit of noise in the caller code.
 
+#### foreach
+
+Another combinator, besides it might not be so useful as _fmap_ and _bind_, is _foreach_ which allows to run a function,
+a side-effect, that does not return any value, so only executes an action with the wrapped value as a parameter. 
+
+Given a nullable _N[A]_ and a function _f: A -> void_, _foreach_ executes _f_  providing _A_ from _N[A]_ as parameter.
+If _N[A]_ is empty, _foreach_ does nothing.
+
+
+One use-case for _foreach_ is where you would like to log the wrapped value, if any. Otherwise, in case of empty
+nullable, you don't want do anything:
+
+```
+foreach(std::optional{person{}}, log_person);
+```
+
 ## Build
 
 The _Makefile_ wraps the commands to download dependencies (Conan), generate the build configuration, build, run the

--- a/include/absent/absent.h
+++ b/include/absent/absent.h
@@ -3,5 +3,6 @@
 
 #include "absent/bind.h"
 #include "absent/fmap.h"
+#include "absent/foreach.h"
 
 #endif //RVARAGO_ABSENT_ABSENT_H

--- a/include/absent/bind.h
+++ b/include/absent/bind.h
@@ -21,7 +21,7 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto bind(Nullable<A> const& input, Mapper fn) -> decltype(fn(std::declval<A>())) {
-        if (!nullable::empty(input)) {
+        if (nullable::empty(input)) {
             return {};
         }
         return fn(nullable::value(input));

--- a/include/absent/fmap.h
+++ b/include/absent/fmap.h
@@ -21,7 +21,7 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto fmap(Nullable<A> const& input, Mapper fn) -> Nullable<decltype(fn(std::declval<A>()))> {
-        if (!nullable::empty(input)) {
+        if (nullable::empty(input)) {
             return {};
         }
         return fn(nullable::value(input));

--- a/include/absent/foreach.h
+++ b/include/absent/foreach.h
@@ -1,0 +1,26 @@
+#ifndef RVARAGO_ABSENT_FOREACH_H
+#define RVARAGO_ABSENT_FOREACH_H
+
+#include "nullable.h"
+
+namespace rvarago::absent {
+
+    /***
+     * Given a nullable type N<A> (i.e. optional like object), and an unary function f: A -> void:
+     * - When empty: it should do nothing.
+     * - When *not* empty: it should apply the unary function to the input nullable's wrapped only for its side-effect.
+     *
+     * @param input any optional like object that can be checked against empty and provide access to its wrapped value.
+     * @param fn an unary function A -> void.
+     */
+    template <typename A, template <typename> typename Nullable, typename Effect>
+    constexpr auto foreach(Nullable<A> const& input, Effect fn) -> void {
+        if (!nullable::empty(input)) {
+            fn(nullable::value(input));
+        }
+    }
+
+
+}
+
+#endif //RVARAGO_ABSENT_FOREACH_H

--- a/include/absent/nullable.h
+++ b/include/absent/nullable.h
@@ -5,7 +5,7 @@ namespace rvarago::absent::nullable {
 
     template <typename Nullable>
     constexpr auto empty(Nullable const& nullable) -> bool {
-        return static_cast<bool>(nullable);
+        return !nullable;
     }
 
     template <typename A, template <typename> typename Nullable>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(${PROJECT_NAME}
         absent_tests.cpp
         bind_test.cpp
         fmap_test.cpp
+        foreach_test.cpp
 )
 
 target_compile_features(${PROJECT_NAME}

--- a/tests/foreach_test.cpp
+++ b/tests/foreach_test.cpp
@@ -1,0 +1,30 @@
+#include <absent/foreach.h>
+
+#include <optional>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace rvarago::absent;
+
+TEST(foreach, given_AnOptional_when_Empty_should_DoNothing) {
+    int counter = 0;
+    auto const add_to_counter = [&counter](auto const& a){ counter += a; };
+
+    std::optional<int> const empty_optional;
+
+    foreach(empty_optional, add_to_counter);
+
+    EXPECT_EQ(0, counter);
+}
+
+TEST(foreach, given_AnOptional_when_NotEmpty_should_RunTheEffectToAddToTheCounter) {
+    int counter = 0;
+    auto const add_to_counter = [&counter](auto const& a){ counter += a; };
+
+    std::optional<int> const empty_optional{1};
+
+    foreach(empty_optional, add_to_counter);
+
+    EXPECT_EQ(1, counter);
+}


### PR DESCRIPTION
- Introduce new combinator "foreach" to run actions on wrapped value
    
    Given a nullable _N[A]_ and a function _f: A -> void_, _foreach_
    executes _f_  providing _A_ from _N[A]_ as parameter. If _N[A]_
    is empty, _foreach_ does nothing.

- Refactor to invert logic for nullable::empty