### PR TITLE
Change fmap infix version to | instead of &, clean ups, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Mainly:
 * It has to be convertible to bool in order to check the absence of a value.
 * It has to support the de-reference operation to extract the contained value.
 
-(See ```absent/nullable.h``` for more details.)
+(See ```absent/syntax/nullable.h``` for more details.)
 
 One example of a nullable type that models this concept would then be: _std::optional_, which, by the way, is going to
 have a nice [monadic interface](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0798r3.html) soon.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fail:
 auto const zip_code = zip_code(find_address(find_person()));
 ```
 
-A little simpler, isn't it?
+Which is simpler to read and therefore understand.
 
 The problem here is that the introduction of nullable types breaks our ability to compose the code by chaining
 elementary operations. We have to find a way to combine the type-safety of nullable types together with the

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ if (maybe_zip_code) {
 
 To understand the above snippets, here it follows a brief explanation of the combinators _fmap_ and _bind_.
 
-#### fmap
+#### fmap (|)
 
 One of the most basic and useful operations to allow the composition of nullable types is _fmap_. Which roughly
 speaking turns a nullable type containing a value of type _A_ into a functor.
@@ -142,7 +142,7 @@ case the _std::optional_ does not contain a _person_ it simply returns an empty 
 It's also possible to use the non-member overload for _fmap_, but at the call site the user has to wrap the member
 function inside a lambda, which adds a little bit of noise in the caller code.
 
-#### bind
+#### bind (>>)
 
 Another useful combinator is _bind_ which allows the composition of functions which by themselves also return values
 wrapped in a nullable, **partially** modelling a monad.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Meanwhile, _absent_ may be used to fill the gap, and even after the introduction
 _std::optional_ it could still be interesting, since it's agnostic regarding the concrete nullable types, also working
 for types other than _std::optional_ as long as they adhere to the expected concept of a nullable type used by _absent_.
 
+#### Getting started
+
+_absent_ is packaged as a header-only library and, once installed, to get started with it you simply have to include the
+main header _absent/absent.h_, which includes all the combinators. Or you can include each combinator as you need them,
+example _absent/combinators/fmap.h_.
+
+You can find all the combinators inside the namespace _rvarago::absent_.
+
+Since the qualified names may be too verbose, an alias might be helpful.
+
 #### Rewriting the person/address/zip_code example using absent
 
 Using the postfix notation, we can rewrite the above example using _absent_ as:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ auto const maybe_zip_code = fmap(bind(find_person(), find_address), zip_code);
 
 Or using the infix notation based on overloaded symbols:
 ```
-auto const maybe_zip_code = find_person() >> find_address & zip_code;
+auto const maybe_zip_code = find_person() >> find_address | zip_code;
 ````
 
 Almost as simple as the version without using nullable types at all, but with the type-safety brought by them.
@@ -89,7 +89,7 @@ In case _find_address_ and _zip_code_ are member functions, it's possible to wra
 and _bind_. However, overloads are provided to simplify the caller code. Using the infix notation, we can do:
 
 ```
-auto const maybe_zip_code = find_person() >> &person::find_address & &address::zip_code;
+auto const maybe_zip_code = find_person() >> &person::find_address | &address::zip_code;
 if (maybe_zip_code) {
     // You just have to check at the end before making the "final" use of the outcome yielded by the composition chain
 }
@@ -117,13 +117,13 @@ std::optional<int> const empty{};
 std::optional<std::string> const empty_as_string = fmap(empty, int_to_string); // contains nothing
 ```
 
-To simplify the act of chaining multiple operations, an infix notation of _fmap_ is provided via overloading _operator&_:
+To simplify the act of chaining multiple operations, an infix notation of _fmap_ is provided via overloading _operator|_:
 
 ```
 auto const string2int = [](auto const& a){ return std::stoi(a); };
 auto const int2string = [](auto const& a){ return std::to_string(a); };
 std::optional<std::string> const some_zero_as_string{"0"};
-std::optional<std::string> const mapped_some_of_zero_as_string = some_zero_as_string & string2int & int2string; // contains "0"
+std::optional<std::string> const mapped_some_of_zero_as_string = some_zero_as_string | string2int | int2string; // contains "0"
 ```
 
 There's an overload for _fmap_ that accepts a member function that has to be **const** and **parameterless** getter function.
@@ -133,7 +133,7 @@ So you can do this:
 struct person {
     int id() const{ return 1; }
 };
-auto const maybe_id = std::optional{person{}} & &person::id; // contains 1
+auto const maybe_id = std::optional{person{}} | &person::id; // contains 1
 ```
 
 Which calls _id()_ if the std::optional contains a _person_ and wraps it inside a new _std::optional_. Otherwise, in

--- a/include/absent/absent.h
+++ b/include/absent/absent.h
@@ -1,8 +1,8 @@
 #ifndef RVARAGO_ABSENT_ABSENT_H
 #define RVARAGO_ABSENT_ABSENT_H
 
-#include "absent/bind.h"
-#include "absent/fmap.h"
-#include "absent/foreach.h"
+#include "absent/combinators/bind.h"
+#include "absent/combinators/fmap.h"
+#include "absent/combinators/foreach.h"
 
 #endif //RVARAGO_ABSENT_ABSENT_H

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -1,7 +1,7 @@
 #ifndef RVARAGO_ABSENT_BIND_H
 #define RVARAGO_ABSENT_BIND_H
 
-#include "absent/member.h"
+#include "absent/syntax/member.h"
 #include "absent/syntax/nullable.h"
 
 #include <functional>
@@ -31,7 +31,7 @@ namespace rvarago::absent {
      * The same as bind but for a member function that has to be const and parameterless.
      */
     template <typename A, typename B, template <typename> typename Nullable>
-    constexpr auto bind(Nullable<A> const& input, member::Mapper<const A, Nullable<B>> fn) -> Nullable<B> {
+    constexpr auto bind(Nullable<A> const& input, syntax::member::Mapper<const A, Nullable<B>> fn) -> Nullable<B> {
         return bind(input, [&fn](auto const& input_value){ return std::invoke(fn, input_value); });
     }
 
@@ -47,7 +47,7 @@ namespace rvarago::absent {
      * Infix version of bind for a member function.
      */
     template <typename A, typename B, template <typename> typename Nullable>
-    constexpr auto operator>>(Nullable<A> const& input, member::Mapper<const A, Nullable<B>> fn) -> Nullable<B> {
+    constexpr auto operator>>(Nullable<A> const& input, syntax::member::Mapper<const A, Nullable<B>> fn) -> Nullable<B> {
         return bind(input, fn);
     }
 

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -2,7 +2,7 @@
 #define RVARAGO_ABSENT_BIND_H
 
 #include "absent/member.h"
-#include "absent/nullable.h"
+#include "absent/syntax/nullable.h"
 
 #include <functional>
 #include <utility>
@@ -21,10 +21,10 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto bind(Nullable<A> const& input, Mapper fn) -> decltype(fn(std::declval<A>())) {
-        if (nullable::empty(input)) {
+        if (syntax::nullable::empty(input)) {
             return {};
         }
-        return fn(nullable::value(input));
+        return fn(syntax::nullable::value(input));
     }
 
     /***

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -1,8 +1,8 @@
 #ifndef RVARAGO_ABSENT_BIND_H
 #define RVARAGO_ABSENT_BIND_H
 
-#include "member.h"
-#include "nullable.h"
+#include "absent/member.h"
+#include "absent/nullable.h"
 
 #include <functional>
 #include <utility>

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -1,8 +1,8 @@
 #ifndef RVARAGO_ABSENT_FMAP_H
 #define RVARAGO_ABSENT_FMAP_H
 
-#include "member.h"
-#include "nullable.h"
+#include "absent/member.h"
+#include "absent/nullable.h"
 
 #include <functional>
 #include <utility>

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -1,7 +1,7 @@
 #ifndef RVARAGO_ABSENT_FMAP_H
 #define RVARAGO_ABSENT_FMAP_H
 
-#include "absent/member.h"
+#include "absent/syntax/member.h"
 #include "absent/syntax/nullable.h"
 
 #include <functional>
@@ -31,7 +31,7 @@ namespace rvarago::absent {
      * The same as fmap but for a member function that has to be const and parameterless.
      */
     template <typename A, typename B, template <typename> typename Nullable>
-    constexpr auto fmap(Nullable<A> const& input, member::Mapper<const A, B> fn) -> Nullable<B> {
+    constexpr auto fmap(Nullable<A> const& input, syntax::member::Mapper<const A, B> fn) -> Nullable<B> {
         return fmap(input, [&fn](auto const& input_value){ return std::invoke(fn, input_value); });
     }
 
@@ -47,7 +47,7 @@ namespace rvarago::absent {
      * Infix version of fmap for a member function.
      */
     template <typename A, typename B, template <typename> typename Nullable>
-    constexpr auto operator|(Nullable<A> const& input, member::Mapper<const A, B> fn) -> Nullable<B> {
+    constexpr auto operator|(Nullable<A> const& input, syntax::member::Mapper<const A, B> fn) -> Nullable<B> {
         return fmap(input, fn);
     }
 

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -2,7 +2,7 @@
 #define RVARAGO_ABSENT_FMAP_H
 
 #include "absent/member.h"
-#include "absent/nullable.h"
+#include "absent/syntax/nullable.h"
 
 #include <functional>
 #include <utility>
@@ -21,10 +21,10 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto fmap(Nullable<A> const& input, Mapper fn) -> Nullable<decltype(fn(std::declval<A>()))> {
-        if (nullable::empty(input)) {
+        if (syntax::nullable::empty(input)) {
             return {};
         }
-        return fn(nullable::value(input));
+        return fn(syntax::nullable::value(input));
     }
 
     /***

--- a/include/absent/combinators/foreach.h
+++ b/include/absent/combinators/foreach.h
@@ -1,7 +1,7 @@
 #ifndef RVARAGO_ABSENT_FOREACH_H
 #define RVARAGO_ABSENT_FOREACH_H
 
-#include "absent/nullable.h"
+#include "absent/syntax/nullable.h"
 
 namespace rvarago::absent {
 
@@ -15,8 +15,8 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Effect>
     constexpr auto foreach(Nullable<A> const& input, Effect fn) -> void {
-        if (!nullable::empty(input)) {
-            fn(nullable::value(input));
+        if (!syntax::nullable::empty(input)) {
+            fn(syntax::nullable::value(input));
         }
     }
 

--- a/include/absent/combinators/foreach.h
+++ b/include/absent/combinators/foreach.h
@@ -1,7 +1,7 @@
 #ifndef RVARAGO_ABSENT_FOREACH_H
 #define RVARAGO_ABSENT_FOREACH_H
 
-#include "nullable.h"
+#include "absent/nullable.h"
 
 namespace rvarago::absent {
 

--- a/include/absent/fmap.h
+++ b/include/absent/fmap.h
@@ -39,7 +39,7 @@ namespace rvarago::absent {
      * Infix version of fmap.
      */
     template <typename A, template <typename> typename Nullable, typename Mapper>
-    constexpr auto operator&(Nullable<A> const& input, Mapper fn) -> decltype(fmap(input, fn)) {
+    constexpr auto operator|(Nullable<A> const& input, Mapper fn) -> decltype(fmap(input, fn)) {
         return fmap(input, fn);
     }
 
@@ -47,7 +47,7 @@ namespace rvarago::absent {
      * Infix version of fmap for a member function.
      */
     template <typename A, typename B, template <typename> typename Nullable>
-    constexpr auto operator&(Nullable<A> const& input, member::Mapper<const A, B> fn) -> Nullable<B> {
+    constexpr auto operator|(Nullable<A> const& input, member::Mapper<const A, B> fn) -> Nullable<B> {
         return fmap(input, fn);
     }
 

--- a/include/absent/syntax/member.h
+++ b/include/absent/syntax/member.h
@@ -1,7 +1,7 @@
 #ifndef RVARAGO_ABSENT_MEMBER_H
 #define RVARAGO_ABSENT_MEMBER_H
 
-namespace rvarago::absent::member {
+namespace rvarago::absent::syntax::member {
     template<typename A, typename B>
     using Mapper = B (A::*)() const;
 }

--- a/include/absent/syntax/nullable.h
+++ b/include/absent/syntax/nullable.h
@@ -1,7 +1,7 @@
 #ifndef RVARAGO_ABSENT_NULLABLE_H
 #define RVARAGO_ABSENT_NULLABLE_H
 
-namespace rvarago::absent::nullable {
+namespace rvarago::absent::syntax::nullable {
 
     template <typename Nullable>
     constexpr auto empty(Nullable const& nullable) -> bool {

--- a/tests/absent_tests.cpp
+++ b/tests/absent_tests.cpp
@@ -13,7 +13,7 @@ TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCode_when_allAreNo
     auto const find_address = [](auto const&){return std::optional{address{}};};
     auto const zip_code = [](auto const&){return "123";};
 
-    EXPECT_EQ(std::optional{"123"}, find_person() >> find_address & zip_code);
+    EXPECT_EQ(std::optional{"123"}, find_person() >> find_address | zip_code);
 }
 
 TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCode_when_anyIsEmpty_shouldReturnAnEmptyZipCode) {
@@ -28,9 +28,9 @@ TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCode_when_anyIsEmp
 
     auto const zip_code = [](auto const&){return "123";};
 
-    EXPECT_FALSE(find_person() >> find_address_empty & zip_code);
-    EXPECT_FALSE(find_person_empty() >> find_address & zip_code);
-    EXPECT_FALSE(find_person_empty() >> find_address_empty & zip_code);
+    EXPECT_FALSE(find_person() >> find_address_empty | zip_code);
+    EXPECT_FALSE(find_person_empty() >> find_address | zip_code);
+    EXPECT_FALSE(find_person_empty() >> find_address_empty | zip_code);
 }
 
 TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCodeAsMemberFunction_when_allAreNotEmpty_shouldReturnTheZipCode) {
@@ -46,10 +46,10 @@ TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCodeAsMemberFuncti
     auto const find_person = []{return std::optional{person{}};};
     auto const find_person_empty = []{return std::optional<person>{};};
 
-    EXPECT_EQ(std::optional{"123"}, find_person() >> &person::find_address & &address::zip_code);
-    EXPECT_FALSE(find_person() >> &person::find_address_empty & &address::zip_code);
-    EXPECT_FALSE(find_person_empty() >> &person::find_address & &address::zip_code);
-    EXPECT_FALSE(find_person_empty() >> &person::find_address_empty & &address::zip_code);
+    EXPECT_EQ(std::optional{"123"}, find_person() >> &person::find_address | &address::zip_code);
+    EXPECT_FALSE(find_person() >> &person::find_address_empty | &address::zip_code);
+    EXPECT_FALSE(find_person_empty() >> &person::find_address | &address::zip_code);
+    EXPECT_FALSE(find_person_empty() >> &person::find_address_empty | &address::zip_code);
 }
 
 int main(int argc, char **argv) {

--- a/tests/bind_test.cpp
+++ b/tests/bind_test.cpp
@@ -1,4 +1,4 @@
-#include <absent/bind.h>
+#include <absent/combinators/bind.h>
 
 #include <optional>
 #include <string>

--- a/tests/fmap_test.cpp
+++ b/tests/fmap_test.cpp
@@ -1,4 +1,4 @@
-#include <absent/fmap.h>
+#include <absent/combinators/fmap.h>
 
 #include <optional>
 #include <string>

--- a/tests/fmap_test.cpp
+++ b/tests/fmap_test.cpp
@@ -12,8 +12,8 @@ TEST(fmap, given_AnOptional_when_Empty_should_ReturnAnEmptyOptional) {
 
     std::optional<int> const empty_optional;
 
-    EXPECT_FALSE(empty_optional & increment);
-    EXPECT_FALSE(empty_optional & increment & increment);
+    EXPECT_FALSE(empty_optional | increment);
+    EXPECT_FALSE(empty_optional | increment | increment);
 }
 
 TEST(fmap, given_AnOptional_when_NotEmpty_should_ReturnNewOptionalWithTheMappedValue) {
@@ -21,9 +21,9 @@ TEST(fmap, given_AnOptional_when_NotEmpty_should_ReturnNewOptionalWithTheMappedV
 
     std::optional<int> const some_zero{0};
 
-    EXPECT_EQ(std::optional(1), some_zero & increment);
-    EXPECT_EQ(std::optional(2), some_zero & increment & increment);
-    EXPECT_EQ(std::optional(3), some_zero & increment & increment & increment);
+    EXPECT_EQ(std::optional(1), some_zero | increment);
+    EXPECT_EQ(std::optional(2), some_zero | increment | increment);
+    EXPECT_EQ(std::optional(3), some_zero | increment | increment | increment);
 }
 
 TEST(fmap, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOptionalWithTheMappedValueOfTheNewType) {
@@ -32,14 +32,14 @@ TEST(fmap, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOpt
 
     std::optional<std::string> const some_zero_as_string{"0"};
 
-    EXPECT_EQ(std::optional(0), some_zero_as_string & string_to_int);
-    EXPECT_EQ(std::optional("0"), some_zero_as_string & string_to_int & int_to_string);
+    EXPECT_EQ(std::optional(0), some_zero_as_string | string_to_int);
+    EXPECT_EQ(std::optional("0"), some_zero_as_string | string_to_int | int_to_string);
 }
 
 TEST(fmap, given_AnOptionalAndAMemberFunction_when_Mapping_should_ReturnTheMappedValueWrappedInAnOptional) {
     struct person {
         int id() const{ return 1;}
     };
-    EXPECT_EQ(std::optional(1), std::optional{person{}} & &person::id);
-    EXPECT_FALSE(std::optional<person>{} & &person::id);
+    EXPECT_EQ(std::optional(1), std::optional{person{}} | &person::id);
+    EXPECT_FALSE(std::optional<person>{} | &person::id);
 }

--- a/tests/foreach_test.cpp
+++ b/tests/foreach_test.cpp
@@ -1,4 +1,4 @@
-#include <absent/foreach.h>
+#include <absent/combinators/foreach.h>
 
 #include <optional>
 #include <string>


### PR DESCRIPTION
- docs: Add section "Gettting started" with headers/namespaces

- docs: Rephrase comparison against non-nullable example

- Move member.h to syntax/ and wrap it inside syntax namespace

- Move nullable.h to syntax/ and wrap it inside syntax namespace

 - Move combinators (fmap.h, bind.h, foreach.h) to combinators/

- docs: List infix notation in the section's name

- Use operator| instead of operator& for fmap
    
    Since it reads better and looks like the fairly well-known "pipe"
    operation.