### PR TITLE
Make it possible to customize nullable via template specializations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,16 @@ as long as it adheres to the concept of a nullable type expected by _absent_.
 
 Mainly:
 
+* It has to have a type parameter.
+* It has to be default constructible in order to express an empty state.
+
+And to work out of the box, it has to have the following properties:
+
 * It has to be convertible to bool in order to check the absence of a value.
 * It has to support the de-reference operation to extract the contained value.
 
-(See ```absent/syntax/nullable.h``` for more details.)
+However, these last two requirements can be adapted by providing template specializations.
+See ```absent/syntax/nullable.h``` for more details, and ```test/customnullable_test.cpp``` for an example.
 
 One example of a nullable type that models this concept would then be: _std::optional_, which, by the way, is going to
 have a nice [monadic interface](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0798r3.html) soon.

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -22,7 +22,7 @@ namespace rvarago::absent {
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto bind(Nullable<A> const& input, Mapper fn) -> decltype(fn(std::declval<A>())) {
         if (syntax::nullable::empty<A, Nullable>::_(input)) {
-            return {};
+            return decltype(fn(std::declval<A>())){};
         }
         return fn(syntax::nullable::value<A, Nullable>::_(input));
     }

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -21,10 +21,10 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto bind(Nullable<A> const& input, Mapper fn) -> decltype(fn(std::declval<A>())) {
-        if (syntax::nullable::empty(input)) {
+        if (syntax::nullable::empty<A, Nullable>::_(input)) {
             return {};
         }
-        return fn(syntax::nullable::value(input));
+        return fn(syntax::nullable::value<A, Nullable>::_(input));
     }
 
     /***

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -21,10 +21,10 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto fmap(Nullable<A> const& input, Mapper fn) -> Nullable<decltype(fn(std::declval<A>()))> {
-        if (syntax::nullable::empty(input)) {
+        if (syntax::nullable::empty<A, Nullable>::_(input)) {
             return {};
         }
-        return fn(syntax::nullable::value(input));
+        return fn(syntax::nullable::value<A, Nullable>::_(input));
     }
 
     /***

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -22,9 +22,9 @@ namespace rvarago::absent {
     template <typename A, template <typename> typename Nullable, typename Mapper>
     constexpr auto fmap(Nullable<A> const& input, Mapper fn) -> Nullable<decltype(fn(std::declval<A>()))> {
         if (syntax::nullable::empty<A, Nullable>::_(input)) {
-            return {};
+            return Nullable<decltype(fn(std::declval<A>()))>{};
         }
-        return fn(syntax::nullable::value<A, Nullable>::_(input));
+        return Nullable{fn(syntax::nullable::value<A, Nullable>::_(input))};
     }
 
     /***

--- a/include/absent/combinators/foreach.h
+++ b/include/absent/combinators/foreach.h
@@ -15,8 +15,8 @@ namespace rvarago::absent {
      */
     template <typename A, template <typename> typename Nullable, typename Effect>
     constexpr auto foreach(Nullable<A> const& input, Effect fn) -> void {
-        if (!syntax::nullable::empty(input)) {
-            fn(syntax::nullable::value(input));
+        if (!syntax::nullable::empty<A, Nullable>::_(input)) {
+            fn(syntax::nullable::value<A, Nullable>::_(input));
         }
     }
 

--- a/include/absent/syntax/nullable.h
+++ b/include/absent/syntax/nullable.h
@@ -3,15 +3,19 @@
 
 namespace rvarago::absent::syntax::nullable {
 
-    template <typename Nullable>
-    constexpr auto empty(Nullable const& nullable) -> bool {
-        return !nullable;
-    }
+    template <typename A, template <typename> typename Nullable>
+    struct empty final {
+        static constexpr auto _(Nullable<A> const& nullable) -> bool {
+            return !nullable;
+        }
+    };
 
     template <typename A, template <typename> typename Nullable>
-    constexpr auto value(Nullable<A> const& nullable) ->  A {
-        return *nullable;
-    }
+    struct value final {
+        static constexpr auto _(Nullable<A> const &nullable) -> A {
+            return *nullable;
+        }
+    };
 }
 
 #endif //RVARAGO_ABSENT_NULLABLE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 add_executable(${PROJECT_NAME}
         absent_tests.cpp
         bind_test.cpp
+        customnullable_test.cpp
         fmap_test.cpp
         foreach_test.cpp
 )

--- a/tests/absent_tests.cpp
+++ b/tests/absent_tests.cpp
@@ -1,6 +1,8 @@
 #include <absent/absent.h>
 
+#include <optional>
 #include <utility>
+
 #include <gtest/gtest.h>
 
 using namespace rvarago::absent;

--- a/tests/customnullable_test.cpp
+++ b/tests/customnullable_test.cpp
@@ -8,8 +8,8 @@ using namespace rvarago::absent;
 namespace {
     template<typename T>
     struct custom_nullable final {
-        custom_nullable() = default;
-        custom_nullable(T val) : value{std::move(val)}, has_value(true) {}
+        explicit custom_nullable() = default;
+        explicit custom_nullable(T val) : value{std::move(val)}, has_value(true) {}
 
         T value;
         bool const has_value{false};

--- a/tests/customnullable_test.cpp
+++ b/tests/customnullable_test.cpp
@@ -1,4 +1,53 @@
-//
-// Created by rvarago on 16.05.19.
-//
+#include <absent/absent.h>
 
+#include <utility>
+#include <gtest/gtest.h>
+
+using namespace rvarago::absent;
+
+namespace {
+    template<typename T>
+    struct custom_nullable final {
+        custom_nullable() = default;
+        custom_nullable(T val) : value{std::move(val)}, has_value(true) {}
+
+        T value;
+        bool const has_value{false};
+    };
+
+    template <typename T>
+    bool operator==(custom_nullable<T> const& rhs, custom_nullable<T> const& lhs) {
+        return rhs.has_value && lhs.has_value && rhs.value == rhs.value;
+    }
+}
+
+namespace rvarago::absent::syntax::nullable {
+
+    template <typename A>
+    struct empty<A, custom_nullable> final {
+        static constexpr auto _(custom_nullable<A> const& nullable) -> bool {
+            return !nullable.has_value;
+        }
+    };
+
+    template <typename A>
+    struct value<A, custom_nullable> final {
+        static constexpr auto _(custom_nullable<A> const &nullable) -> A {
+            return nullable.value;
+        }
+    };
+}
+
+TEST(custom_nullable, given_aCustomNullable_when_notInvokeAbsentOperations_shouldUseSpecializations) {
+    struct person{};
+    struct address{};
+
+    auto const find_person = []{ return custom_nullable{person{}}; };
+    auto const find_person_empty = []{ return custom_nullable<person>{}; };
+
+    auto const find_address = [](auto const&){ return custom_nullable{address{}}; };
+    auto const zip_code = [](auto const&){return "123";};
+
+    EXPECT_EQ(custom_nullable{"123"}, find_person() >> find_address | zip_code);
+    EXPECT_FALSE((find_person_empty() >> find_address | zip_code).has_value);
+}

--- a/tests/customnullable_test.cpp
+++ b/tests/customnullable_test.cpp
@@ -1,0 +1,4 @@
+//
+// Created by rvarago on 16.05.19.
+//
+


### PR DESCRIPTION
- Don't require implicit conversions for nullable types

- Make it possible to specialize for nullable with different syntax
  
    Therefore, the requirements to use absent become simpler to achieve,
    being possible to use with types that don't adhere to the expected
    API.

- tests: Explicitly include <optional> for absent_test

- Wrap functions of syntax::nullable inside static member functions
    
    That allows template partial specializations, and therefore
    customization by client code for APIs that doesn't adhere with the one
    expected by absent.