### PR TITLE
Add support to install absent and export its target into the system via Modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(rvarago::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}
         INTERFACE
-            include
+            $<INSTALL_INTERFACE:include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
 target_compile_features(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(absent LANGUAGES CXX)
 
+# Definition
+
 add_library(${PROJECT_NAME} INTERFACE)
 
 add_library(rvarago::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -16,6 +18,32 @@ target_compile_features(${PROJECT_NAME}
         INTERFACE
             cxx_std_17
 )
+
+# Installation
+
+include(GNUInstallDirs)
+
+# Generate the config file with the target
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Config
+)
+install(DIRECTORY include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Make the target be importable from the installation directory
+install(EXPORT ${PROJECT_NAME}Config
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        NAMESPACE rvarago::
+)
+
+# Make the target be importable from the build directory via package registry
+export(EXPORT ${PROJECT_NAME}Config
+       NAMESPACE rvarago::
+)
+export(PACKAGE ${PROJECT_NAME})
+
+# Tests
 
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(absent)
+project(absent LANGUAGES CXX)
 
 add_library(${PROJECT_NAME} INTERFACE)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PROJECT_NAME=absent
 PROFILE=../profiles/common
+BUILD_TESTING=true
 
 .PHONY: all test compile gen dep mk clean env env-test
 
@@ -18,7 +19,7 @@ compile: gen
 	cd build && cmake --build .
 
 gen: dep
-	cd build && cmake ..
+	cd build && cmake -D BUILD_TESTING=${BUILD_TESTING} ..
 
 dep: mk
 	cd build && conan install .. --build=missing -pr ${PROFILE}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROJECT_NAME=absent
 PROFILE=../profiles/common
 BUILD_TESTING=true
 
-.PHONY: all test compile gen dep mk clean env env-test
+.PHONY: all test install compile gen dep mk clean env env-test
 
 all: compile
 
@@ -11,6 +11,9 @@ env:
 
 env-test: env
 	docker run --rm -t ${PROJECT_NAME}:0.1
+
+install: compile
+	cd build && cmake --build . --target install
 
 test: compile
 	cd build && ctest .

--- a/README.md
+++ b/README.md
@@ -9,27 +9,31 @@ A simple library to compose nullable types in a declarative style for the modern
 Handling nullable types has always been forcing us to add a significant amount of boilerplate in our code, in such a
 way that it sometimes even hides the business logic which we are trying to express in our code.
 
-Consider an API that returns nullable types, such as std::optional<A>, for each operation that may fail. A fairly
-common pattern in C++ would then be:
+Consider an API that makes use of nullable types, such as std::optional<A>. We may have the following functions:
+
+```
+std::optional<person> find_person() const;
+std::optional<address> find_address(person const&) const;
+zip zip_code(address const&) const;
+```
+
+A fairly common pattern in C++ would then be:
 
 ```
 auto const maybe_person = find_person();
-if (maybe_person) {
-    auto const maybe_address = find_address(*maybe_person);
-    if (maybe_address) {
-        auto const zip_code = zip_code(*maybe_address);
-        // You have to check many times against empty. Moreover, you have to do it in the middle of your logic
-    }
-}
+if (!maybe_person) return;
+
+auto const maybe_address = find_address(*maybe_person);
+if (!maybe_address) return;
+
+auto const zip_code = zip_code(*maybe_address);
 ```
 
-We have mixed business logic with error handling, it'd be nice to have these two concerns apart from each other.
+We have mixed business logic with error handling, it'd be nice to have these two concerns apart from each other. It's a lot
+of boilerplate to achieve such a simple requirement as obtaining the zip code of a given person.
 
-Obviously, it's possible to break the snippet up into separated and well-named functions. But we still
-have a lot of code to accomplish such a simple task as obtaining a person's zip code.
-
-Now, compare it against the code without employing nullable types whatsoever, and of course, expecting that nothing can
-fail:
+Now, compare it against the code that does not make use of nullable types whatsoever. And of course, it expects
+that nothing can fail:
 
 ```
 auto const zip_code = zip_code(find_address(find_person()));
@@ -54,7 +58,7 @@ ones that you're using.
 Hence, an interesting caveat of _absent_ is that:
 
 > _absent_ is agnostic regarding the concrete implementation of a nullable type that you're using, 
-as long as it adheres to the concept of a nullable type expected by _absent_.
+as long as it adheres to the concept of a nullable type expected by the library.
 
 Mainly:
 
@@ -69,18 +73,17 @@ And to work out of the box, it has to have the following properties:
 However, these last two requirements can be adapted by providing template specializations.
 See ```absent/syntax/nullable.h``` for more details, and ```test/customnullable_test.cpp``` for an example.
 
-One example of a nullable type that models this concept would then be: _std::optional_, which, by the way, is going to
+One example of a nullable type that models this concept would obviously then be: _std::optional_, which, by the way, is going to
 have a nice [monadic interface](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0798r3.html) soon.
 
-Meanwhile, _absent_ may be used to fill the gap, and even after the introduction of a monadic interface for
-_std::optional_ it could still be interesting, since it's agnostic regarding the concrete nullable types, also working
-for types other than _std::optional_ as long as they adhere to the expected concept of a nullable type used by _absent_.
+Meanwhile, _absent_ may be used to fill that gap. And even after it could still be interesting, since it's agnostic
+regarding the concrete nullable types, also working for optional-like types other than _std::optional_.
 
 ### Getting started
 
 _absent_ is packaged as a header-only library and, once installed, to get started with it you simply have to include the
 main header _absent/absent.h_, which includes all the combinators. Or you can include each combinator as you need them,
-example _absent/combinators/fmap.h_.
+for example _absent/combinators/fmap.h_.
 
 You can find all the combinators inside the namespace _rvarago::absent_.
 
@@ -94,15 +97,27 @@ Using the postfix notation, we can rewrite the above example using _absent_ as:
 auto const maybe_zip_code = fmap(bind(find_person(), find_address), zip_code);
 ````
 
-Or using the infix notation based on overloaded symbols:
+Or using the infix notation based on overloaded operators:
+
 ```
 auto const maybe_zip_code = find_person() >> find_address | zip_code;
 ````
 
-Almost as simple as the version without using nullable types at all, but with the type-safety brought by them.
+Almost as easy to read as the version without using nullable types, but with the expressiveness and type-safety
+brought by them.
 
-In case _find_address_ and _zip_code_ are member functions, it's possible to wrap them inside lambdas and use _fmap_
-and _bind_. However, overloads are provided to simplify the caller code. Using the infix notation, we can do:
+In the case where _find_address_ and _zip_code_ are "getter" member functions, such as:
+
+```
+std::optional<address> person::find_address() const;
+zip address::zip_code() const;
+```
+
+It's possible to wrap them inside lambdas and use _fmap_ and _bind_ as we did before.
+
+However, overloads that accept getter member functions are also provided to simplify the caller code even more.
+
+So, using the infix notation, we can do:
 
 ```
 auto const maybe_zip_code = find_person() >> &person::find_address | &address::zip_code;
@@ -144,7 +159,7 @@ std::optional<std::string> const mapped_some_of_zero_as_string = some_zero_as_st
                                                                     | int2string; // contains "0"
 ```
 
-There's an overload for _fmap_ that accepts a member function that has to be **const** and **parameterless** getter function.
+There's also an overload for _fmap_ that accepts a member function that has to be **const** and **parameterless** getter function.
 So you can do this:
 
 ```
@@ -158,18 +173,22 @@ Which calls _id()_ if the std::optional contains a _person_ and wraps it inside 
 case the _std::optional_ does not contain a _person_ it simply returns an empty _std::optional_.
 
 It's also possible to use the non-member overload for _fmap_, but at the call site the user has to wrap the member
-function inside a lambda, which adds a little bit of noise in the caller code.
+function inside a lambda, which adds a little bit of noise to the caller code.
 
 #### bind (>>)
 
 Another useful combinator is _bind_ which allows the composition of functions which by themselves also return values
-wrapped in a nullable, **partially** modelling a monad.
+wrapped in a nullable. Roughly speaking, it's modelling a monad.
 
 Given a nullable _N[A]_ and a function _f: A -> N[B]_, _bind_ uses _f_ to map over _N[A]_, yielding another nullable
-_N[B]_. The main difference if compared to _fmap_ is that if you apply _f_ using _fmap_ you end up with _N[N[B]]_.
-Whereas _bind_ knows how it should flatten _N[N[B]]_ into _N[B]_. Think of a scenario where you invoke a function
-that might fail, and use a nullable to represent such failure, and then you use the value inside the nullable to invoke
-another function that might also fail, and so and so forth. That's a good use case to make use of _bind_.
+_N[B]_.
+
+The main difference if compared to _fmap_ is that if you apply _f_ using _fmap_ you end up with _N[N[B]]_.
+Whereas _bind_ knows how it should flatten _N[N[B]]_ into _N[B]_ after applying the mapping function.
+
+Suppose a scenario where you invoke a function that might fail, so you use a nullable to represent such failure.
+And then you use the value inside the nullable to invoke another function that might fail as well. So and so forth.
+That's precisely a good use-case to make for _bind_.
 
 Example:
 
@@ -192,7 +211,7 @@ std::optional<std::string> const mapped_some_of_zero_as_string = some_zero_as_st
                                                                     >> maybe_int2string; // contains "0"
 ```
 
-Similar to _fmap_, there's an overload for _bind_ that accepts a member function that has to be **const** and
+Similar to _fmap_, there's also an overload for _bind_ that accepts a member function that has to be **const** and
 **parameterless** getter function. So you can do this:
 
 ```
@@ -206,7 +225,7 @@ Which calls _id()_ if the std::optional contains a _person_ already wrapped in a
 case the _std::optional_ does not contain a _person_ it simply returns an empty _std::optional_.
 
 It's also possible to use the non-member overload for _bind_, but at the call site the user has to wrap the member
-function inside a lambda, which adds a little bit of noise in the caller code.
+function inside a lambda, which adds a little bit of noise to the caller code.
 
 #### foreach
 
@@ -214,14 +233,20 @@ Another combinator is _foreach_ which allows running a function that does not re
 action with the wrapped value as a parameter. Since the action does not return anything, it's only executed because of
 its side-effect, like logging a message to the console, saving an entity in the database, etc.
 
-Given a nullable _N[A]_ and a function _f: A -> void_, _foreach_ executes _f_  providing _A_ from _N[A]_ as a parameter.
-If _N[A]_ is empty, _foreach_ does nothing.
+Given a nullable _N[A]_ and a function _f: A -> void_, _foreach_ executes _f_  providing _A_ from _N[A]_ as argument to _f_.
+If _N[A]_ is empty, then _foreach_ does nothing.
 
 One use-case for _foreach_ is where you would like to log the wrapped value if any. Otherwise, in case of empty
 nullable, you don't want to do anything:
 
 ```
-foreach(std::optional{person{}}, log_person);
+foreach(std::optional{person{}}, log);
+```
+
+Where _log_ may be:
+
+```
+void log(person const&) const;
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -260,14 +260,22 @@ unit tests, and clear the build folder.
 make
 ```
 
-It assumes that the default profile (*profiles/common*) applies to your build, if not, then you can specify your
-profile by appending _PROFILE_ as:
+By default, it also builds the unit tests, you can disable the behavior by:
+
+```
+make BUILD_TESTING=false
+```
+
+
+The build always assumes that the default profile (*profiles/common*) applies to your build. If that's not, then you
+can specify your profile by setting _PROFILE_ as:
  
 ```
 make PROFILE=<path_to_your_profile>
 ```
 
-* Run the unit tests:
+
+* To run the unit tests:
 
 ```
 make test
@@ -279,9 +287,9 @@ make test
 make clean
 ```
 
-### Run tests inside a Docker container
+### Run unit tests inside a Docker container
 
-Optionally, it's possible to run the tests inside a Docker container by running:
+Optionally, it's also possible to run the unit tests inside a Docker container by executing:
 
 ```
 make env-test

--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ can specify your profile by setting _PROFILE_ as:
 make PROFILE=<path_to_your_profile>
 ```
 
-
 * To run the unit tests:
 
 ```
@@ -293,4 +292,22 @@ Optionally, it's also possible to run the unit tests inside a Docker container b
 
 ```
 make env-test
+```
+
+## Installation
+
+To install the _absent_:
+
+```
+sudo make install
+```
+
+This will install it into _${CMAKE_INSTALL_PREFIX}/include/absent_. And it also make it available from the local CMake
+package repository.
+
+Then, it's possible to import _absent_ into some target _myExample_ by simply adding the following to its _CMakeLists.txt_:
+
+```
+find_package(absent REQUIRED)
+target_link_libraries(myExample rvarago::absent)
 ```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,10 +15,15 @@ target_compile_features(${PROJECT_NAME}
             cxx_std_17
 )
 
-if (NOT MSVC)
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
     target_compile_options(${PROJECT_NAME}
             PRIVATE
                 -Wall -Wextra -Werror -ansi -pedantic
+    )
+else()
+    target_compile_options(${PROJECT_NAME}
+            PRIVATE
+                /Wall /W4
     )
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(absent_tests)
+project(absent_tests LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 


### PR DESCRIPTION
* cmake: Add support to install and export the target into the system
    
    Therefore, downstreams can use absent more easily via modern CMake, i.e.
    by simply:
    
    find_package(absent REQUIRED)
    target_link_libraries(myapp rvarago::absent)

* cmake: Include headers based on generator expressions
    
    Therefore, it should work when including the library somewhere else.

* cmake: Specify LANGUAGE CXX for projects

* cmake: Add support to build without tests

* cmake: Handle warning levels depending on the compiler

* docs: Improve examples and provide an better explanation