### PR TITLE
conan: Add support to create a package for absent via Conan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ services:
 
 script:
   - make env-test
+  - make env-conan-package

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_TESTING=true
 PACKAGE_VERSION=0.0.1
 PACKAGE_REFERENCE=${PROJECT_NAME}/${PACKAGE_VERSION}@rvarago/stable
 
-.PHONY: all conan-package test install compile gen dep mk clean env env-test
+.PHONY: all conan-upload conan-package test install compile gen dep mk clean env env-test
 
 all: compile
 
@@ -19,6 +19,9 @@ install: compile
 
 conan-package: test
 	conan create . ${PACKAGE_REFERENCE}
+
+conan-upload: conan-package
+	conan upload ${PACKAGE_REFERENCE} --all -r ${REMOTE}
 
 test: compile
 	cd build && ctest .

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 PROJECT_NAME=absent
 PROFILE=../profiles/common
 BUILD_TESTING=true
+PACKAGE_VERSION=0.0.1
+PACKAGE_REFERENCE=${PROJECT_NAME}/${PACKAGE_VERSION}@rvarago/stable
 
-.PHONY: all test install compile gen dep mk clean env env-test
+.PHONY: all conan-package test install compile gen dep mk clean env env-test
 
 all: compile
 
@@ -14,6 +16,9 @@ env-test: env
 
 install: compile
 	cd build && cmake --build . --target install
+
+conan-package: test
+	conan create . ${PACKAGE_REFERENCE}
 
 test: compile
 	cd build && ctest .

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_TESTING=true
 PACKAGE_VERSION=0.0.1
 PACKAGE_REFERENCE=${PROJECT_NAME}/${PACKAGE_VERSION}@rvarago/stable
 
-.PHONY: all conan-upload conan-package test install compile gen dep mk clean env env-test
+.PHONY: all conan-upload conan-package env-conan-package test install compile gen dep mk clean env env-test
 
 all: compile
 
@@ -13,6 +13,9 @@ env:
 
 env-test: env
 	docker run --rm -t ${PROJECT_NAME}:0.1
+
+env-conan-package: env
+	docker run --rm -t ${PROJECT_NAME}:0.1 make conan-package
 
 install: compile
 	cd build && cmake --build . --target install

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Optionally, it's also possible to run the unit tests inside a Docker container b
 make env-test
 ```
 
-## Installation
+## Installing on the system
 
 To install _absent_:
 
@@ -324,3 +324,13 @@ following commands to its _CMakeLists.txt_:
 find_package(absent REQUIRED)
 target_link_libraries(myExample rvarago::absent)
 ```
+
+## Packaging via Conan
+
+To generate a package via Conan:
+
+```
+make conan-package
+```
+
+This will build the package _absent_, run a test package, and then install it in the local Conan cache.

--- a/README.md
+++ b/README.md
@@ -334,3 +334,14 @@ make conan-package
 ```
 
 This will build the package _absent_, run a test package, and then install it in the local Conan cache.
+
+
+### Deploying to remote
+
+To deploy the package to a remote repository:
+
+```
+make conan-upload REMOTE=<REMOTE_NAME>
+```
+
+Will deploy the package to the specified remote.

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,14 +2,23 @@ from conans import ConanFile
 
 class AbsentConan(ConanFile):
     name        = "absent"
-    version     = "0.1"
+
     description = "A simple library to compose nullable types in a declarative style for the modern C++ programmer"
     author      = "Rafael Varago (rvarago)"
     topics      = ("nullable-type", "composition", "monadic-interface", "declarative-programming")
     license     = "MIT"
-    url         = "https://github.com/rvarago/absent"
+    homepage    = "https://github.com/rvarago/absent"
+    url         = homepage
+    exports = ["README.md", "LICENSE"]
 
-    settings    = "os", "compiler", "arch", "build_type"
     requires    = "gtest/1.8.0@bincrafters/stable"
     generators  = "cmake_find_package"
 
+    exports_sources = "include/*"
+    no_copy_source = True
+
+    def package(self):
+        self.copy("*.h")
+
+    def package_id(self):
+        self.info.header_only()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(absent_test_package LANGUAGES CXX)
+
+set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+
+find_package(absent REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+enable_testing()
+add_test(NAME ${PROJECT_NAME}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+        COMMAND ${PROJECT_NAME}
+)
+
+target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            absent::absent
+)
+
+target_compile_features(${PROJECT_NAME}
+        PRIVATE
+            cxx_std_17
+)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake
+import os
+
+class AbsentTestConan(ConanFile):
+    name        = "absent_test_package"
+    author      = "Rafael Varago (rvarago)"
+
+    generators  = "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        self.run(".{}{}".format(os.sep, self.name))

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <optional>
+#include "absent/absent.h"
+
+using namespace rvarago::absent;
+
+int main() {
+    auto constexpr maybe_an_approximate_answer = std::optional{41};
+    auto constexpr exact_answer = (maybe_an_approximate_answer | [](auto const& el) { return el + 1; }).value();
+    static_assert(42 == exact_answer);
+    std::cout << "rvarago::absent works! The exact answer is: " << exact_answer << '\n';
+    return 0;
+}


### PR DESCRIPTION
* travis: Add test for packaging via CI 

*  conan: Add support to upload packages to Conan

The command:

make conan-upload REMOTE=<REMOTE_NAME>

Deploy the package to the specified remote.

* conan: Add support to create a package via Conan

The command:

make conan-package

Will build a conan package and deploy it to the local cache.
