### PR TITLE
feature: Add support for composing unique_ptr

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,14 @@ And to work out of the box, it has to have the following properties:
 * It has to provide a member function _value()_ to extract the contained value.
 
 However, these last two requirements can be adapted by providing template specializations. And some adaptors are also
-available, such as for ```boost::optional``` (see ```absent/adaptors/boost_optional.h``` for details).
+available, such as for:
+
+* ```boost::optional```.
+* ```std::unique_ptr```.
+
+**Note**: Despite the fact _std::unique_ptr_ is supported, I would not recommend using to express nullability. Since a
+pointer usually has more than this sole meaning, e.g. it can be used in order to enable sub-typing polymorphism.
+Therefore, using may cause confusion.
 
 More details can be found in ```absent/syntax/nullable.h```.
 

--- a/include/absent/adaptors/unique_ptr.h
+++ b/include/absent/adaptors/unique_ptr.h
@@ -1,0 +1,34 @@
+#ifndef RVARAGO_ABSENT_UNIQUE_PTR_H
+#define RVARAGO_ABSENT_UNIQUE_PTR_H
+
+#include <memory>
+
+namespace rvarago::absent::syntax::nullable {
+
+    template <typename Mapper, typename A, typename... Rest>
+    struct binder<std::unique_ptr, Mapper, A, Rest...> final {
+
+        static constexpr decltype(auto) bind(std::unique_ptr<A, Rest...> input, Mapper fn) {
+            using Result = decltype(fn(std::declval<A>()));
+            if (!input) {
+                return Result{};
+            }
+            return fn(*input.release());
+        }
+
+    };
+
+    template <typename Mapper, typename A, typename... Rest>
+    struct fmapper<std::unique_ptr, Mapper, A, Rest...> final {
+
+        static constexpr decltype(auto) fmap(std::unique_ptr<A, Rest...> input, Mapper fn) {
+            using Result = decltype(fn(std::declval<A>()));
+            auto const flat_mapper = [&fn](auto value){ return std::make_unique<Result>(fn(std::move(value))); };
+            return binder<std::unique_ptr, decltype(flat_mapper), A, Rest...>::bind(std::move(input), flat_mapper);
+        }
+
+    };
+
+}
+
+#endif //RVARAGO_ABSENT_UNIQUE_PTR_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(${PROJECT_NAME}
         customnullable_test.cpp
         fmap_test.cpp
         foreach_test.cpp
+        unique_ptr_test.cpp
 )
 
 target_compile_features(${PROJECT_NAME}

--- a/tests/unique_ptr_test.cpp
+++ b/tests/unique_ptr_test.cpp
@@ -1,0 +1,48 @@
+#include <absent/absent.h>
+#include <absent/adaptors/unique_ptr.h>
+
+#include <gtest/gtest.h>
+
+using namespace rvarago::absent;
+
+TEST(unique_ptr, given_andUniquePtr_when_InvokeAbsent_shouldMoveItAndLeaveItNullAfterwards) {
+    auto zero = std::make_unique<int>(0);
+    auto const one = std::move(zero) | [](auto value){ return value + 1; };
+
+    EXPECT_FALSE(zero);
+    EXPECT_TRUE(one);
+    EXPECT_EQ(1, *one);
+}
+
+TEST(unique_ptr, given_andUniquePtr_when_notEmpty_shouldApplyForeachToIncrementCounter) {
+    int counter = 0;
+    auto const add_to_counter = [&counter](auto const& a){ counter += a; };
+
+    auto one = std::make_unique<int>(1);
+    foreach(std::move(one), add_to_counter);
+
+    EXPECT_FALSE(one);
+    EXPECT_EQ(1, counter);
+}
+
+TEST(unique_ptr, given_anUniquePtr_when_notEmpty_shouldReturnEmptyUniquePtr) {
+    struct person{};
+    struct address{};
+
+    auto const find_person_empty = []() -> std::unique_ptr<person> { return nullptr; };
+    auto const find_address = [](auto const&){ return std::make_unique<address>(); };
+    auto const zip_code = [](auto const&){return "123";};
+
+    EXPECT_FALSE(find_person_empty() >> find_address | zip_code);
+}
+
+TEST(unique_ptr, given_anUniquePtr_when_notNotEmpty_shouldReturnNewUniquePtr) {
+    struct person{};
+    struct address{};
+
+    auto const find_person = []{ return std::make_unique<person>(); };
+    auto const find_address = [](auto const&){ return std::make_unique<address>(); };
+    auto const zip_code = [](auto const&){return "123";};
+
+    EXPECT_EQ("123", *(find_person() >> find_address | zip_code));
+}


### PR DESCRIPTION
**Note**: Despite the fact _std::unique_ptr_ is supported, I would not
recommend using to express nullability. Since a
pointer usually has more than this sole meaning, e.g. it can be used in
order to enable sub-typing polymorphism.

Therefore, using may cause confusion.