### PR TITLE
Clean ups for tests and don't run tests when packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 
 script:
   - make env-test
-  - make env-conan-package PACKAGE_VERSION=ci
+  - make env-conan-package WITH_TESTS=false PACKAGE_VERSION=ci

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,6 @@ export(PACKAGE ${PROJECT_NAME})
 
 include(CTest)
 
-if(BUILD_TESTING)
+if(WITH_TESTS)
     add_subdirectory(tests)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ env-test: env
 	docker run --rm ${PROJECT_NAME}
 
 env-conan-package: env
-	docker run --rm ${PROJECT_NAME} make conan-package PACKAGE_VERSION=${PACKAGE_VERSION}
+	docker run --rm ${PROJECT_NAME} make conan-package BUILD_TESTING=${BUILD_TESTING} PACKAGE_VERSION=${PACKAGE_VERSION}
 
 install: compile
 	cd build && cmake --build . --target install
 
-conan-package: test
+conan-package: compile
 	conan create . ${PACKAGE_REFERENCE}
 
 test: compile

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME        = absent
 PROFILE             = ../profiles/common
-BUILD_TESTING       = true
+WITH_TESTS          = true
 PACKAGE_VERSION     =
 PACKAGE_REFERENCE   = ${PROJECT_NAME}/${PACKAGE_VERSION}@rvarago/stable
 
@@ -15,7 +15,7 @@ env-test: env
 	docker run --rm ${PROJECT_NAME}
 
 env-conan-package: env
-	docker run --rm ${PROJECT_NAME} make conan-package BUILD_TESTING=${BUILD_TESTING} PACKAGE_VERSION=${PACKAGE_VERSION}
+	docker run --rm ${PROJECT_NAME} make conan-package WITH_TESTS=${WITH_TESTS} PACKAGE_VERSION=${PACKAGE_VERSION}
 
 install: compile
 	cd build && cmake --build . --target install
@@ -30,7 +30,7 @@ compile: gen
 	cd build && cmake --build .
 
 gen: dep
-	cd build && cmake -D BUILD_TESTING=${BUILD_TESTING} ..
+	cd build && cmake -D WITH_TESTS=${WITH_TESTS} ..
 
 dep: mk
 	cd build && conan install .. --build=missing -pr ${PROFILE}

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ make
 By default, it also builds the unit tests, you can disable the behavior by:
 
 ```
-make BUILD_TESTING=false
+make WITH_TESTS=false
 ```
 
 
@@ -344,4 +344,4 @@ To generate a package via Conan:
 make conan-package
 ```
 
-This will build the package _absent_, run a test package, and then install it in the local Conan cache.
+This will build the package _absent_, run the test package, and then install it in the local Conan cache.

--- a/tests/absent_tests.cpp
+++ b/tests/absent_tests.cpp
@@ -7,51 +7,53 @@
 
 using namespace rvarago::absent;
 
-TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCode_when_allAreNotEmpty_shouldReturnTheZipCode) {
-    struct person{};
-    struct address{};
+namespace {
 
-    auto const find_person = []{ return std::optional{person{}}; };
-    auto const find_address = [](auto const&){ return std::optional{address{}}; };
-    auto const zip_code = [](auto const&){return "123";};
+    struct person final {};
+    struct address final {};
 
-    EXPECT_EQ(std::optional{"123"}, find_person() >> find_address | zip_code);
-}
+    TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCode_when_allAreNotEmpty_shouldReturnTheZipCode) {
+        auto const find_person = [] { return std::optional{person{}}; };
+        auto const find_address = [](auto const &) { return std::optional{address{}}; };
+        auto const zip_code = [](auto const &) { return 42; };
 
-TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCode_when_anyIsEmpty_shouldReturnAnEmptyZipCode) {
-    struct person{};
-    struct address{};
+        EXPECT_EQ(std::optional{42}, find_person() >> find_address | zip_code);
+    }
 
-    auto const find_person = []{ return std::optional{person{}}; };
-    auto const find_address = [](auto const&){ return std::optional{address{}}; };
+    TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCode_when_anyIsEmpty_shouldReturnAnEmptyZipCode) {
+        auto const find_person = [] { return std::optional{person{}}; };
+        auto const find_address = [](auto const &) { return std::optional{address{}}; };
 
-    auto const find_person_empty = []() -> std::optional<person> { return std::nullopt; };
-    auto const find_address_empty = [](auto const&) -> std::optional<address> { return std::nullopt; };
+        auto const find_person_empty = []() -> std::optional<person> { return std::nullopt; };
+        auto const find_address_empty = [](auto const &) -> std::optional<address> { return std::nullopt; };
 
-    auto const zip_code = [](auto const&){return "123";};
+        auto const zip_code = [](auto const &) { return 42; };
 
-    EXPECT_FALSE(find_person() >> find_address_empty | zip_code);
-    EXPECT_FALSE(find_person_empty() >> find_address | zip_code);
-    EXPECT_FALSE(find_person_empty() >> find_address_empty | zip_code);
-}
+        EXPECT_FALSE(find_person() >> find_address_empty | zip_code);
+        EXPECT_FALSE(find_person_empty() >> find_address | zip_code);
+        EXPECT_FALSE(find_person_empty() >> find_address_empty | zip_code);
+    }
 
-TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCodeAsMemberFunction_when_allAreNotEmpty_shouldReturnTheZipCode) {
-    struct address{
-        std::string zip_code() const {return "123";}
-    };
+    TEST(combine_bind_fmap, given_anHierarchyOfPersonAddressAndZipCodeAsMemberFunction_when_allAreNotEmpty_shouldReturnTheZipCode) {
 
-    struct person{
-        std::optional<address> find_address() const { return address{}; }
-        std::optional<address> find_address_empty() const { return std::nullopt; }
-    };
+        struct address {
+            int zip_code() const { return 42; }
+        };
 
-    auto const find_person = []{ return std::optional{person{}}; };
-    auto const find_person_empty = []{ return std::optional<person>{}; };
+        struct person {
+            std::optional<address> find_address() const { return address{}; }
+            std::optional<address> find_address_empty() const { return std::nullopt; }
+        };
 
-    EXPECT_EQ(std::optional{"123"}, find_person() >> &person::find_address | &address::zip_code);
-    EXPECT_FALSE(find_person() >> &person::find_address_empty | &address::zip_code);
-    EXPECT_FALSE(find_person_empty() >> &person::find_address | &address::zip_code);
-    EXPECT_FALSE(find_person_empty() >> &person::find_address_empty | &address::zip_code);
+        auto const find_person = [] { return std::optional{person{}}; };
+        auto const find_person_empty = [] { return std::optional<person>{}; };
+
+        EXPECT_EQ(std::optional{42}, find_person() >> &person::find_address | &address::zip_code);
+        EXPECT_FALSE(find_person() >> &person::find_address_empty | &address::zip_code);
+        EXPECT_FALSE(find_person_empty() >> &person::find_address | &address::zip_code);
+        EXPECT_FALSE(find_person_empty() >> &person::find_address_empty | &address::zip_code);
+    }
+
 }
 
 int main(int argc, char **argv) {

--- a/tests/bind_test.cpp
+++ b/tests/bind_test.cpp
@@ -21,9 +21,9 @@ TEST(bind, given_AnOptional_when_NotEmpty_should_ReturnNewOptionalWithTheMappedV
 
     std::optional<int> const some_zero{0};
 
-    EXPECT_EQ(std::optional(1), some_zero >> maybe_increment);
-    EXPECT_EQ(std::optional(2), some_zero >> maybe_increment >> maybe_increment);
-    EXPECT_EQ(std::optional(3), some_zero >> maybe_increment >> maybe_increment >> maybe_increment);
+    EXPECT_EQ(std::optional{1}, some_zero >> maybe_increment);
+    EXPECT_EQ(std::optional{2}, some_zero >> maybe_increment >> maybe_increment);
+    EXPECT_EQ(std::optional{3}, some_zero >> maybe_increment >> maybe_increment >> maybe_increment);
 }
 
 TEST(bind, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOptionalWithTheMappedValueOfTheNewType) {
@@ -32,8 +32,8 @@ TEST(bind, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOpt
 
     std::optional<std::string> const some_zero_as_string{"0"};
 
-    EXPECT_EQ(std::optional(0), some_zero_as_string >> maybe_string_to_int);
-    EXPECT_EQ(std::optional("0"), some_zero_as_string >> maybe_string_to_int >> maybe_int_to_string);
+    EXPECT_EQ(std::optional{0}, some_zero_as_string >> maybe_string_to_int);
+    EXPECT_EQ(std::optional{"0"}, some_zero_as_string >> maybe_string_to_int >> maybe_int_to_string);
 }
 
 TEST(bind, given_AnOptional_when_NotEmptyAndThenEmpty_should_ReturnAnEmptyOptional) {

--- a/tests/fmap_test.cpp
+++ b/tests/fmap_test.cpp
@@ -21,9 +21,9 @@ TEST(fmap, given_AnOptional_when_NotEmpty_should_ReturnNewOptionalWithTheMappedV
 
     std::optional<int> const some_zero{0};
 
-    EXPECT_EQ(std::optional(1), some_zero | increment);
-    EXPECT_EQ(std::optional(2), some_zero | increment | increment);
-    EXPECT_EQ(std::optional(3), some_zero | increment | increment | increment);
+    EXPECT_EQ(std::optional{1}, some_zero | increment);
+    EXPECT_EQ(std::optional{2}, some_zero | increment | increment);
+    EXPECT_EQ(std::optional{3}, some_zero | increment | increment | increment);
 }
 
 TEST(fmap, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOptionalWithTheMappedValueOfTheNewType) {
@@ -32,8 +32,8 @@ TEST(fmap, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOpt
 
     std::optional<std::string> const some_zero_as_string{"0"};
 
-    EXPECT_EQ(std::optional(0), some_zero_as_string | string_to_int);
-    EXPECT_EQ(std::optional("0"), some_zero_as_string | string_to_int | int_to_string);
+    EXPECT_EQ(std::optional{0}, some_zero_as_string | string_to_int);
+    EXPECT_EQ(std::optional{"0"}, some_zero_as_string | string_to_int | int_to_string);
 }
 
 TEST(fmap, given_AnOptionalAndAMemberFunction_when_Mapping_should_ReturnTheMappedValueWrappedInAnOptional) {
@@ -41,6 +41,6 @@ TEST(fmap, given_AnOptionalAndAMemberFunction_when_Mapping_should_ReturnTheMappe
         int id() const{ return 1; }
     };
 
-    EXPECT_EQ(std::optional(1), std::optional{person{}} | &person::id);
+    EXPECT_EQ(std::optional{1}, std::optional{person{}} | &person::id);
     EXPECT_FALSE(std::optional<person>{} | &person::id);
 }

--- a/tests/unique_ptr_test.cpp
+++ b/tests/unique_ptr_test.cpp
@@ -5,44 +5,45 @@
 
 using namespace rvarago::absent;
 
-TEST(unique_ptr, given_andUniquePtr_when_InvokeAbsent_should_MoveItAndLeaveItNullAfterwards) {
-    auto zero = std::make_unique<int>(0);
-    auto const one = std::move(zero) | [](auto value){ return value + 1; };
+namespace {
 
-    EXPECT_FALSE(zero);
-    EXPECT_TRUE(one);
-    EXPECT_EQ(1, *one);
-}
+    struct person final {};
+    struct address final {};
 
-TEST(unique_ptr, given_andUniquePtr_when_notEmpty_should_ApplyForeachToIncrementCounter) {
-    int counter = 0;
-    auto const add_to_counter = [&counter](auto const& a){ counter += a; };
+    TEST(unique_ptr, given_andUniquePtr_when_InvokeAbsent_should_MoveItAndLeaveItNullAfterwards) {
+        auto zero = std::make_unique<int>(0);
+        auto const one = std::move(zero) | [](auto value) { return value + 1; };
 
-    auto one = std::make_unique<int>(1);
-    foreach(std::move(one), add_to_counter);
+        EXPECT_FALSE(zero);
+        EXPECT_TRUE(one);
+        EXPECT_EQ(1, *one);
+    }
 
-    EXPECT_FALSE(one);
-    EXPECT_EQ(1, counter);
-}
+    TEST(unique_ptr, given_andUniquePtr_when_notEmpty_should_ApplyForeachToIncrementCounter) {
+        int counter = 0;
+        auto const add_to_counter = [&counter](auto const &a) { counter += a; };
 
-TEST(unique_ptr, given_anUniquePtr_when_Empty_should_ReturnEmptyUniquePtr) {
-    struct person{};
-    struct address{};
+        auto one = std::make_unique<int>(1);
+        foreach(std::move(one), add_to_counter);
 
-    auto const find_person_empty = []() -> std::unique_ptr<person> { return nullptr; };
-    auto const find_address = [](auto const&){ return std::make_unique<address>(); };
-    auto const zip_code = [](auto const&){return "123";};
+        EXPECT_FALSE(one);
+        EXPECT_EQ(1, counter);
+    }
 
-    EXPECT_FALSE(find_person_empty() >> find_address | zip_code);
-}
+    TEST(unique_ptr, given_anUniquePtr_when_Empty_should_ReturnEmptyUniquePtr) {
+        auto const find_person_empty = []() -> std::unique_ptr<person> { return nullptr; };
+        auto const find_address = [](auto const &) { return std::make_unique<address>(); };
+        auto const zip_code = [](auto const &) { return 42; };
 
-TEST(unique_ptr, given_anUniquePtr_when_NotEmpty_should_ReturnNewTransformedUniquePtr) {
-    struct person{};
-    struct address{};
+        EXPECT_FALSE(find_person_empty() >> find_address | zip_code);
+    }
 
-    auto const find_person = []{ return std::make_unique<person>(); };
-    auto const find_address = [](auto const&){ return std::make_unique<address>(); };
-    auto const zip_code = [](auto const&){return "123";};
+    TEST(unique_ptr, given_anUniquePtr_when_NotEmpty_should_ReturnNewTransformedUniquePtr) {
+        auto const find_person = [] { return std::make_unique<person>(); };
+        auto const find_address = [](auto const &) { return std::make_unique<address>(); };
+        auto const zip_code = [](auto const &) { return 42; };
 
-    EXPECT_EQ("123", *(find_person() >> find_address | zip_code));
+        EXPECT_EQ(42, *(find_person() >> find_address | zip_code));
+    }
+
 }


### PR DESCRIPTION
* refactor: Rename BUILD_TESTING to WITH_TESTS that's more meaningful
* makefile: Don't build tests when creating a package
* cleanup: Use brace-init when instantiating an std::optional
* cleanup: Simplify implementation in the tests for absent_tests
* cleanup: Remove unnecessary duplication in the tests for unique_ptr
* cleanup: Remove unnecessary duplication in the tests for either