### PR TITLE
change: Use _ instead of bind or fmap inside template classes

### DIFF
--- a/include/absent/adapters/boost_optional.h
+++ b/include/absent/adapters/boost_optional.h
@@ -10,7 +10,7 @@ namespace rvarago::absent::syntax::nullable {
     template <typename Mapper, typename A>
     struct binder<boost::optional, Mapper, A> final {
 
-        static constexpr decltype(auto) bind(boost::optional<A> input, Mapper fn) {
+        static constexpr decltype(auto) _(boost::optional<A> input, Mapper fn) {
             if (!input) {
                 return decltype(fn(std::declval<A>())){};
             }

--- a/include/absent/adapters/either.h
+++ b/include/absent/adapters/either.h
@@ -13,7 +13,7 @@ namespace rvarago::absent::syntax {
         template<typename Mapper, typename A, typename E>
         struct binder<std::variant, Mapper, A, E> final {
 
-            static constexpr decltype(auto) bind(std::variant<A, E> input, Mapper fn) {
+            static constexpr decltype(auto) _(std::variant<A, E> input, Mapper fn) {
                 using Result = decltype(fn(std::declval<A>()));
                 if (!std::holds_alternative<A>(input)) {
                     return Result{std::get<E>(input)};
@@ -26,10 +26,10 @@ namespace rvarago::absent::syntax {
         template<typename Mapper, typename A, typename E>
         struct fmapper<std::variant, Mapper, A, E> final {
 
-            static constexpr decltype(auto) fmap(std::variant<A, E> input, Mapper fn) {
+            static constexpr decltype(auto) _(std::variant<A, E> input, Mapper fn) {
                 using Result = std::variant<decltype(fn(std::declval<A>())), E>;
                 auto const flat_mapper = [&fn](auto value) { return Result{fn(std::move(value))}; };
-                return binder<std::variant, decltype(flat_mapper), A, E>::bind(std::move(input), flat_mapper);
+                return binder<std::variant, decltype(flat_mapper), A, E>::_(std::move(input), flat_mapper);
             }
         };
     }

--- a/include/absent/adapters/unique_ptr.h
+++ b/include/absent/adapters/unique_ptr.h
@@ -8,7 +8,7 @@ namespace rvarago::absent::syntax::nullable {
     template <typename Mapper, typename A, typename... Rest>
     struct binder<std::unique_ptr, Mapper, A, Rest...> final {
 
-        static constexpr decltype(auto) bind(std::unique_ptr<A, Rest...> input, Mapper fn) {
+        static constexpr decltype(auto) _(std::unique_ptr<A, Rest...> input, Mapper fn) {
             using Result = decltype(fn(std::declval<A>()));
             if (!input) {
                 return Result{};
@@ -21,10 +21,10 @@ namespace rvarago::absent::syntax::nullable {
     template <typename Mapper, typename A, typename... Rest>
     struct fmapper<std::unique_ptr, Mapper, A, Rest...> final {
 
-        static constexpr decltype(auto) fmap(std::unique_ptr<A, Rest...> input, Mapper fn) {
+        static constexpr decltype(auto) _(std::unique_ptr<A, Rest...> input, Mapper fn) {
             using Result = decltype(fn(std::declval<A>()));
             auto const flat_mapper = [&fn](auto value){ return std::make_unique<Result>(fn(std::move(value))); };
-            return binder<std::unique_ptr, decltype(flat_mapper), A, Rest...>::bind(std::move(input), flat_mapper);
+            return binder<std::unique_ptr, decltype(flat_mapper), A, Rest...>::_(std::move(input), flat_mapper);
         }
 
     };

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -21,7 +21,7 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename Mapper, typename A, typename... Rest>
     constexpr decltype(auto) bind(Nullable<A, Rest...> input, Mapper fn) {
-        return syntax::nullable::binder<Nullable, Mapper, A, Rest...>::bind(std::move(input), fn);
+        return syntax::nullable::binder<Nullable, Mapper, A, Rest...>::_(std::move(input), fn);
     }
 
     /***

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -21,7 +21,7 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename Mapper, typename A, typename... Rest>
     constexpr decltype(auto) fmap(Nullable<A, Rest...> input, Mapper fn) {
-        return syntax::nullable::fmapper<Nullable, Mapper, A, Rest...>::fmap(std::move(input), fn);
+        return syntax::nullable::fmapper<Nullable, Mapper, A, Rest...>::_(std::move(input), fn);
     }
 
     /***

--- a/include/absent/syntax/nullable.h
+++ b/include/absent/syntax/nullable.h
@@ -18,7 +18,7 @@ namespace rvarago::absent::syntax::nullable {
     template <template <typename...> typename Nullable, typename Mapper, typename A, typename... Rest>
     struct binder final {
 
-        static constexpr auto bind(Nullable<A, Rest...> input, Mapper fn) -> decltype(fn(std::declval<A>())) {
+        static constexpr auto _(Nullable<A, Rest...> input, Mapper fn) -> decltype(fn(std::declval<A>())) {
             if (!input.has_value()) {
                 return decltype(fn(std::declval<A>())){};
             }
@@ -38,10 +38,10 @@ namespace rvarago::absent::syntax::nullable {
     template <template <typename...> typename Nullable, typename Mapper, typename A, typename... Rest>
     struct fmapper final {
 
-        static constexpr auto fmap(Nullable<A, Rest...> input, Mapper fn) -> Nullable<decltype(fn(std::declval<A>()))> {
+        static constexpr auto _(Nullable<A, Rest...> input, Mapper fn) -> Nullable<decltype(fn(std::declval<A>()))> {
             using Result = Nullable<decltype(fn(std::declval<A>()))>;
             auto const flat_mapper = [&fn](auto value){ return Result{fn(std::move(value))}; };
-            return binder<Nullable, decltype(flat_mapper), A, Rest...>::bind(std::move(input), flat_mapper);
+            return binder<Nullable, decltype(flat_mapper), A, Rest...>::_(std::move(input), flat_mapper);
         }
 
     };

--- a/tests/customnullable_test.cpp
+++ b/tests/customnullable_test.cpp
@@ -26,7 +26,7 @@ namespace rvarago::absent::syntax::nullable {
     template <typename Mapper, typename A>
     struct binder<custom_nullable, Mapper, A> final {
 
-        static constexpr decltype(auto) bind(custom_nullable<A> input, Mapper fn) {
+        static constexpr decltype(auto) _(custom_nullable<A> input, Mapper fn) {
             if (!input.has_value) {
                 return decltype(fn(std::declval<A>())){};
             }


### PR DESCRIPTION
Since they only exist for technical purposes.