### PR TITLE
Add test to check memory leaks in the adapter for unique_ptr and some clean ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,17 +262,15 @@ void log(person const&) const;
 
 #### eval
 
-Another combinator is _eval_ which returns the wrapped value inside nullable if present, or evaluates the
-fallback function in case the nullable is empty. Therefore, providing a lazy version of ```std::optional<T>::value_or```
-that avoid wasting computations since in that case the evaluation always happens, even if the nullable contains is not
-empty.
+Another combinator is _eval_ which returns the wrapped value inside nullable if present or evaluates the
+fallback function in case the nullable is empty. Therefore, providing a lazy version of ```std::optional::value_or```
+that avoids wasting computations since in that case the evaluation always happens, even if the nullable is not empty.
 
 Given a nullable _N[A]_ and a function _f: void -> A_, _eval_ returns the wrapped _A_ inside _N[A]_ if not empty,
 or evaluates _f_ that returns a fallback instance of _A_.
 
 One use-case for _eval_ is where you happen to have a default value for the nullable, but its computation is
 expensive or it has some side-effect that only makes sense to be executed in case of an empty nullable. For instance:
-
 
 ```
 eval(std::optional{person{}}, make_fallback_person);

--- a/tests/bind_test.cpp
+++ b/tests/bind_test.cpp
@@ -7,52 +7,58 @@
 
 using namespace rvarago::absent;
 
-TEST(bind, given_AnOptional_when_Empty_should_DoNothing) {
-    auto const maybe_increment = [](auto const& a){ return std::optional{a + 1}; };
+namespace {
 
-    std::optional<int> const none;
+    TEST(bind, given_ANullable_when_Empty_should_DoNothing) {
+        auto const maybe_increment = [](auto const &a) { return std::optional{a + 1}; };
 
-    EXPECT_FALSE(none >> maybe_increment);
-    EXPECT_FALSE(none >> maybe_increment >> maybe_increment);
-}
+        std::optional<int> const none;
 
-TEST(bind, given_AnOptional_when_NotEmpty_should_ReturnNewOptionalWithTheMappedValue) {
-    auto const maybe_increment = [](auto const& a){ return std::optional{a + 1}; };
+        EXPECT_FALSE(none >> maybe_increment);
+        EXPECT_FALSE(none >> maybe_increment >> maybe_increment);
+    }
 
-    std::optional<int> const some_zero{0};
+    TEST(bind, given_ANullable_when_NotEmpty_should_ReturnNewNullableWithTheMappedValue) {
+        auto const maybe_increment = [](auto const &a) { return std::optional{a + 1}; };
 
-    EXPECT_EQ(std::optional{1}, some_zero >> maybe_increment);
-    EXPECT_EQ(std::optional{2}, some_zero >> maybe_increment >> maybe_increment);
-    EXPECT_EQ(std::optional{3}, some_zero >> maybe_increment >> maybe_increment >> maybe_increment);
-}
+        std::optional<int> const some_zero{0};
 
-TEST(bind, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOptionalWithTheMappedValueOfTheNewType) {
-    auto const maybe_string_to_int = [](auto const& a){ return std::optional{std::stoi(a)}; };
-    auto const maybe_int_to_string = [](auto const& a){ return std::optional{std::to_string(a)}; };
+        EXPECT_EQ(std::optional{1}, some_zero >> maybe_increment);
+        EXPECT_EQ(std::optional{2}, some_zero >> maybe_increment >> maybe_increment);
+        EXPECT_EQ(std::optional{3}, some_zero >> maybe_increment >> maybe_increment >> maybe_increment);
+    }
 
-    std::optional<std::string> const some_zero_as_string{"0"};
+    TEST(bind,
+         given_ANullable_when_NotEmptyAndMappedToANewType_should_ReturnNewNullableWithTheMappedValueOfTheNewType) {
+        auto const maybe_string_to_int = [](auto const &a) { return std::optional{std::stoi(a)}; };
+        auto const maybe_int_to_string = [](auto const &a) { return std::optional{std::to_string(a)}; };
 
-    EXPECT_EQ(std::optional{0}, some_zero_as_string >> maybe_string_to_int);
-    EXPECT_EQ(std::optional{"0"}, some_zero_as_string >> maybe_string_to_int >> maybe_int_to_string);
-}
+        std::optional<std::string> const some_zero_as_string{"0"};
 
-TEST(bind, given_AnOptional_when_NotEmptyAndThenEmpty_should_ReturnAnEmptyOptional) {
-    auto const maybe_string_to_int = [](auto const& a){ return std::optional{std::stoi(a)}; };
-    auto const to_of_string_empty = [](auto const&) -> std::optional<std::string> { return std::nullopt; };
+        EXPECT_EQ(std::optional{0}, some_zero_as_string >> maybe_string_to_int);
+        EXPECT_EQ(std::optional{"0"}, some_zero_as_string >> maybe_string_to_int >> maybe_int_to_string);
+    }
 
-    std::optional<std::string> const some_zero_as_string{"0"};
+    TEST(bind, given_ANullable_when_NotEmptyAndThenEmpty_should_ReturnAnEmptyNullable) {
+        auto const maybe_string_to_int = [](auto const &a) { return std::optional{std::stoi(a)}; };
+        auto const to_of_string_empty = [](auto const &) -> std::optional<std::string> { return std::nullopt; };
 
-    EXPECT_FALSE(some_zero_as_string >> maybe_string_to_int >> to_of_string_empty);
-}
+        std::optional<std::string> const some_zero_as_string{"0"};
 
-TEST(bind, given_AnOptionalAndAMemberFunction_when_Mapping_should_ReturnTheMappedValueWrappedInAnFlattenOptional) {
-    struct person {
-        std::optional<int> id() const{ return 1;}
-        std::optional<int> id_empty() const{ return std::nullopt;}
-    };
+        EXPECT_FALSE(some_zero_as_string >> maybe_string_to_int >> to_of_string_empty);
+    }
 
-    EXPECT_EQ(std::optional{1}, std::optional{person{}} >> &person::id);
-    EXPECT_FALSE(std::optional<person>{} >> &person::id);
-    EXPECT_FALSE(std::optional{person{}} >> &person::id_empty);
-    EXPECT_FALSE(std::optional<person>{} >> &person::id_empty);
+    TEST(bind, given_ANullableAndAMemberFunction_when_Mapping_should_ReturnTheMappedValueWrappedInAnFlattenNullable) {
+        struct person {
+            std::optional<int> id() const { return 1; }
+
+            std::optional<int> id_empty() const { return std::nullopt; }
+        };
+
+        EXPECT_EQ(std::optional{1}, std::optional{person{}} >> &person::id);
+        EXPECT_FALSE(std::optional<person>{} >> &person::id);
+        EXPECT_FALSE(std::optional{person{}} >> &person::id_empty);
+        EXPECT_FALSE(std::optional<person>{} >> &person::id_empty);
+    }
+
 }

--- a/tests/boost_optional_test.cpp
+++ b/tests/boost_optional_test.cpp
@@ -11,7 +11,7 @@ namespace {
     struct person final {};
     struct address final {};
 
-    TEST(boost_optional, given_aBoostOptional_when_IsError_should_ReturnError) {
+    TEST(boost_optional, given_ANullable_when_Empty_should_ReturnAnEmptyNullable) {
         boost::optional<person> const person_empty = boost::none;
         auto const find_address = [](auto const &) { return boost::optional<address>{address{}}; };
         auto const zip_code = [](auto const &) { return 42; };
@@ -19,7 +19,7 @@ namespace {
         EXPECT_FALSE(person_empty >> find_address | zip_code);
     }
 
-    TEST(boost_optional, given_aBoostOptional_when_NotEmpty_shouldReturnNewTransformedBoostOptional) {
+    TEST(boost_optional, given_ANullable_when_NotEmpty_should_ReturnANewTransformedNullable) {
         auto const person_some =  boost::optional<person>{person{}};
         auto const find_address = [](auto const &) { return boost::optional<address>{address{}}; };
         auto const zip_code = [](auto const &) { return 42; };
@@ -30,7 +30,7 @@ namespace {
         EXPECT_EQ(42, maybe_zip_code.value());
     }
 
-    TEST(boost_optional, given_aBoostOptional_when_Empty_should_CallTheFallback) {
+    TEST(boost_optional, given_ANullable_when_Empty_should_CallTheFallback) {
         auto const to_minus_one = [] { return -1; };
 
         boost::optional<int> const none;

--- a/tests/either_test.cpp
+++ b/tests/either_test.cpp
@@ -30,21 +30,21 @@ namespace {
     }
 
     TEST(either, given_ANullable_when_Empty_should_ReturnAnEmptyNullable) {
-        auto const find_person_error = [] { return either<person, error>{error{}}; };
+        auto const person_empty = either<person, error>{error{}};
         auto const find_address = [](auto const &) { return either<address, error>{address{}}; };
         auto const zip_code = [](auto const &) { return 42; };
 
-        auto const either_zip_code = find_person_error() >> find_address | zip_code;
+        auto const either_zip_code = person_empty >> find_address | zip_code;
 
         expect_alternative_of_type<error>(either_zip_code);
     }
 
     TEST(either, given_ANullable_when_NotEmpty_should_ReturnANewTransformedNullable) {
-        auto const find_person = [] { return either<person, error>{person{}}; };
+        auto const person_some = either<person, error>{person{}};
         auto const find_address = [](auto const &) { return either<address, error>{address{}}; };
         auto const zip_code = [](auto const &) { return 42; };
 
-        auto const either_zip_code = find_person() >> find_address | zip_code;
+        auto const either_zip_code = person_some >> find_address | zip_code;
 
         expect_alternative_of_type<int>(either_zip_code);
         EXPECT_EQ(42, std::get<int>(either_zip_code));

--- a/tests/either_test.cpp
+++ b/tests/either_test.cpp
@@ -18,7 +18,7 @@ namespace {
     }
 
 
-    TEST(either, given_andEither_when_notError_shouldApplyForeachToIncrementCounter) {
+    TEST(either, given_ANullable_when_NotEmpty_should_ApplyForeachToIncrementTheCounter) {
         int counter = 0;
         auto const add_to_counter = [&counter](auto const &a) { counter += a; };
 
@@ -29,7 +29,7 @@ namespace {
         EXPECT_EQ(1, counter);
     }
 
-    TEST(either, given_anEither_when_IsError_should_ReturnError) {
+    TEST(either, given_ANullable_when_Empty_should_ReturnAnEmptyNullable) {
         auto const find_person_error = [] { return either<person, error>{error{}}; };
         auto const find_address = [](auto const &) { return either<address, error>{address{}}; };
         auto const zip_code = [](auto const &) { return 42; };
@@ -39,7 +39,7 @@ namespace {
         expect_alternative_of_type<error>(either_zip_code);
     }
 
-    TEST(either, given_anEither_when_NotError_shouldReturnNewTransformedEither) {
+    TEST(either, given_ANullable_when_NotEmpty_should_ReturnANewTransformedNullable) {
         auto const find_person = [] { return either<person, error>{person{}}; };
         auto const find_address = [](auto const &) { return either<address, error>{address{}}; };
         auto const zip_code = [](auto const &) { return 42; };
@@ -50,7 +50,7 @@ namespace {
         EXPECT_EQ(42, std::get<int>(either_zip_code));
     }
 
-    TEST(either, given_AnOptional_when_Empty_should_CallTheFallback) {
+    TEST(either, given_ANullable_when_Empty_should_CallTheFallback) {
         auto const to_minus_one = [] { return -1; };
 
         auto const none = either<int, error>{error{}};

--- a/tests/eval_test.cpp
+++ b/tests/eval_test.cpp
@@ -9,7 +9,7 @@ using namespace rvarago::absent;
 
 namespace {
 
-    TEST(eval, given_anOptional_when_Empty_should_CallTheFallback) {
+    TEST(eval, given_ANullable_when_Empty_should_CallTheFallback) {
         auto const to_minus_one = [] { return -1; };
 
         std::optional<int> const none;
@@ -17,7 +17,7 @@ namespace {
         EXPECT_EQ(-1, eval(none, to_minus_one));
     }
 
-    TEST(eval, given_anOptional_when_NotEmpty_should_ReturnTheWrappedValue) {
+    TEST(eval, given_ANullable_when_NotEmpty_should_ReturnTheWrappedValue) {
         auto const to_minus_one = [] { return -1; };
 
         auto const one = std::optional<int>{1};

--- a/tests/fmap_test.cpp
+++ b/tests/fmap_test.cpp
@@ -7,40 +7,44 @@
 
 using namespace rvarago::absent;
 
-TEST(fmap, given_AnOptional_when_Empty_should_ReturnAnEmptyOptional) {
-    auto const increment = [](auto const& a){ return a + 1; };
+namespace {
 
-    std::optional<int> const none;
+    TEST(fmap, given_ANullable_when_Empty_should_ReturnAnEmptyNullable) {
+        auto const increment = [](auto const &a) { return a + 1; };
 
-    EXPECT_FALSE(none | increment);
-    EXPECT_FALSE(none | increment | increment);
-}
+        std::optional<int> const none;
 
-TEST(fmap, given_AnOptional_when_NotEmpty_should_ReturnNewOptionalWithTheMappedValue) {
-    auto const increment = [](auto const& a){ return a + 1; };
+        EXPECT_FALSE(none | increment);
+        EXPECT_FALSE(none | increment | increment);
+    }
 
-    std::optional<int> const some_zero{0};
+    TEST(fmap, given_ANullable_when_NotEmpty_should_ReturnANewNullablelWithTheMappedValue) {
+        auto const increment = [](auto const &a) { return a + 1; };
 
-    EXPECT_EQ(std::optional{1}, some_zero | increment);
-    EXPECT_EQ(std::optional{2}, some_zero | increment | increment);
-    EXPECT_EQ(std::optional{3}, some_zero | increment | increment | increment);
-}
+        std::optional<int> const some_zero{0};
 
-TEST(fmap, given_AnOptional_when_NotEmptyAndMappedToANewType_should_ReturnNewOptionalWithTheMappedValueOfTheNewType) {
-    auto const string_to_int = [](auto const& a){ return std::stoi(a); };
-    auto const int_to_string = [](auto const& a){ return std::to_string(a); };
+        EXPECT_EQ(std::optional{1}, some_zero | increment);
+        EXPECT_EQ(std::optional{2}, some_zero | increment | increment);
+        EXPECT_EQ(std::optional{3}, some_zero | increment | increment | increment);
+    }
 
-    std::optional<std::string> const some_zero_as_string{"0"};
+    TEST(fmap, given_ANullable_when_NotEmptyAndMappedToANewType_should_ReturnANewNullableWithTheMappedValueOfTheNewType) {
+        auto const string_to_int = [](auto const &a) { return std::stoi(a); };
+        auto const int_to_string = [](auto const &a) { return std::to_string(a); };
 
-    EXPECT_EQ(std::optional{0}, some_zero_as_string | string_to_int);
-    EXPECT_EQ(std::optional{"0"}, some_zero_as_string | string_to_int | int_to_string);
-}
+        std::optional<std::string> const some_zero_as_string{"0"};
 
-TEST(fmap, given_AnOptionalAndAMemberFunction_when_Mapping_should_ReturnTheMappedValueWrappedInAnOptional) {
-    struct person {
-        int id() const{ return 1; }
-    };
+        EXPECT_EQ(std::optional{0}, some_zero_as_string | string_to_int);
+        EXPECT_EQ(std::optional{"0"}, some_zero_as_string | string_to_int | int_to_string);
+    }
 
-    EXPECT_EQ(std::optional{1}, std::optional{person{}} | &person::id);
-    EXPECT_FALSE(std::optional<person>{} | &person::id);
+    TEST(fmap, given_ANullableAndAMemberFunction_when_Mapping_should_ReturnTheMappedValueWrappedInANullable) {
+        struct person {
+            int id() const { return 1; }
+        };
+
+        EXPECT_EQ(std::optional{1}, std::optional{person{}} | &person::id);
+        EXPECT_FALSE(std::optional<person>{} | &person::id);
+    }
+
 }

--- a/tests/foreach_test.cpp
+++ b/tests/foreach_test.cpp
@@ -7,24 +7,28 @@
 
 using namespace rvarago::absent;
 
-TEST(foreach, given_AnOptional_when_Empty_should_DoNothing) {
-    int counter = 0;
-    auto const add_to_counter = [&counter](auto const& a){ counter += a; };
+namespace {
 
-    std::optional<int> const none;
+    TEST(foreach, given_ANullable_when_Empty_should_DoNothing) {
+        int counter = 0;
+        auto const add_to_counter = [&counter](auto const &a) { counter += a; };
 
-    foreach(none, add_to_counter);
+        std::optional<int> const none;
 
-    EXPECT_EQ(0, counter);
-}
+        foreach(none, add_to_counter);
 
-TEST(foreach, given_AnOptional_when_NotEmpty_should_RunTheEffectToAddToTheCounter) {
-    int counter = 0;
-    auto const add_to_counter = [&counter](auto const& a){ counter += a; };
+        EXPECT_EQ(0, counter);
+    }
 
-    std::optional<int> const some_one{1};
+    TEST(foreach, given_ANullable_when_NotEmpty_should_RunTheEffectToAddToTheCounter) {
+        int counter = 0;
+        auto const add_to_counter = [&counter](auto const &a) { counter += a; };
 
-    foreach(some_one, add_to_counter);
+        std::optional<int> const some_one{1};
 
-    EXPECT_EQ(1, counter);
+        foreach(some_one, add_to_counter);
+
+        EXPECT_EQ(1, counter);
+    }
+
 }

--- a/tests/unique_ptr_test.cpp
+++ b/tests/unique_ptr_test.cpp
@@ -10,7 +10,7 @@ namespace {
     struct person final {};
     struct address final {};
 
-    TEST(unique_ptr, given_anUniquePtr_when_InvokeAbsent_should_MoveItAndLeaveItNullAfterwards) {
+    TEST(unique_ptr, given_ANullable_when_InvokeAbsent_should_MoveItAndLeaveItNullAfterwards) {
         auto zero = std::make_unique<int>(0);
         auto const one = std::move(zero) | [](auto value) { return value + 1; };
 
@@ -19,7 +19,7 @@ namespace {
         EXPECT_EQ(1, *one);
     }
 
-    TEST(unique_ptr, given_anUniquePtr_when_notEmpty_should_ApplyForeachToIncrementCounter) {
+    TEST(unique_ptr, given_ANullable_when_NotEmpty_should_ApplyForeachToIncrementCounter) {
         int counter = 0;
         auto const add_to_counter = [&counter](auto const &a) { counter += a; };
 
@@ -30,7 +30,7 @@ namespace {
         EXPECT_EQ(1, counter);
     }
 
-    TEST(unique_ptr, given_anUniquePtr_when_Empty_should_ReturnEmptyUniquePtr) {
+    TEST(unique_ptr, given_ANullable_when_Empty_should_ReturnAnEmptyNullable) {
         auto const find_person_empty = []() -> std::unique_ptr<person> { return nullptr; };
         auto const find_address = [](auto const &) { return std::make_unique<address>(); };
         auto const zip_code = [](auto const &) { return 42; };
@@ -38,7 +38,7 @@ namespace {
         EXPECT_FALSE(find_person_empty() >> find_address | zip_code);
     }
 
-    TEST(unique_ptr, given_anUniquePtr_when_NotEmpty_should_ReturnNewTransformedUniquePtr) {
+    TEST(unique_ptr, given_ANullable_when_NotEmpty_should_ReturnANewTransformedNullable) {
         auto const find_person = [] { return std::make_unique<person>(); };
         auto const find_address = [](auto const &) { return std::make_unique<address>(); };
         auto const zip_code = [](auto const &) { return 42; };
@@ -46,7 +46,7 @@ namespace {
         EXPECT_EQ(42, *(find_person() >> find_address | zip_code));
     }
 
-    TEST(unique_ptr, given_anUniquePtr_when_Empty_should_CallTheFallback) {
+    TEST(unique_ptr, given_ANullable_when_Empty_should_CallTheFallback) {
         auto const to_minus_one = [] { return -1; };
 
         EXPECT_EQ(-1, eval(std::unique_ptr<int>{}, to_minus_one));

--- a/tests/unique_ptr_test.cpp
+++ b/tests/unique_ptr_test.cpp
@@ -52,4 +52,22 @@ namespace {
         EXPECT_EQ(-1, eval(std::unique_ptr<int>{}, to_minus_one));
     }
 
+    TEST(unique_ptr, given_ANullable_when_NotEmpty_should_CallCtorAndDtorTheSameNumberOfTimes) {
+        static int calls_to_ctor = 0;
+        static int calls_to_dtor = 0;
+
+        struct foo {
+            foo() {++calls_to_ctor;}
+            ~foo() {++calls_to_dtor;}
+        };
+
+        auto const new_some = [] { return std::make_unique<foo>(); };
+        auto const to_new_some = [](auto const &) { return std::make_unique<foo>(); };
+        auto const to_new_some_but_throw_before = [](auto const &) { throw 0; return std::make_unique<foo>(); };
+        auto const to_number = [](auto const &) { return 42; };
+
+        try {new_some() >> to_new_some >> to_new_some_but_throw_before >> to_new_some | to_number;} catch (...) {}
+        EXPECT_EQ(calls_to_ctor, calls_to_dtor) << "Unequal number of calls to Ctor and Dtor: it might cause memory leak";
+    }
+
 }


### PR DESCRIPTION
tests: Simplify notation in the tests for the adapter for either
tests: Add test to check memory leaks in the adapter for unique_ptr
tests: Rename test cases to avoid redundant information
docs: Fix spelling in the eval section