### PR TITLE
Handle multi parameter nullable types correctly in fmap

### DIFF
--- a/include/absent/nullable/instance.h
+++ b/include/absent/nullable/instance.h
@@ -38,13 +38,13 @@ namespace rvarago::absent::nullable::instance {
      */
     template<template<typename...> typename Nullable, typename Mapper, typename A, typename... Rest>
     struct fmapper final {
-        static constexpr auto _(Nullable<A, Rest...> input, Mapper fn) noexcept -> Nullable<decltype(fn(std::declval<A>()))> {
+        static constexpr auto _(Nullable<A, Rest...> input, Mapper fn) noexcept -> Nullable<decltype(fn(std::declval<A>())), Rest...> {
             using ValueT = decltype(fn(std::declval<A>()));
             if (syntax::empty<Nullable, A, Rest...>::_(input)) {
-                return syntax::make_empty<Nullable<A, Rest...>, Nullable<ValueT>>::_(std::move(input));
+                return syntax::make_empty<Nullable<A, Rest...>, Nullable<ValueT, Rest...>>::_(std::move(input));
             }
             auto const value = syntax::value<Nullable, A, Rest...>::_(std::move(input));
-            return syntax::make<Nullable, ValueT>::_(fn(std::move(value)));
+            return syntax::make<Nullable, ValueT, Rest...>::_(fn(std::move(value)));
         }
     };
 

--- a/include/absent/nullable/syntax.h
+++ b/include/absent/nullable/syntax.h
@@ -30,8 +30,9 @@ namespace rvarago::absent::nullable::syntax {
      */
     template <template<typename...> typename Nullable, typename... Rest>
     struct make final {
-        static constexpr auto _(Rest... args) noexcept -> Nullable<Rest...> {
-            return Nullable<Rest...>{std::move(args)...};
+        template <typename... Args>
+        static constexpr auto _(Args&&... args) noexcept -> Nullable<Rest...> {
+            return Nullable<Rest...>{std::forward<Args>(args)...};
         }
     };
 


### PR DESCRIPTION
Assuming both the input and output types use the same list of template parameters except the first one.