### PR TITLE
conan: Depend on gtest via build_requires

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,10 +9,10 @@ class AbsentConan(ConanFile):
     license     = "MIT"
     homepage    = "https://github.com/rvarago/absent"
     url         = homepage
-    exports = ["README.md", "LICENSE"]
+    exports     = ["README.md", "LICENSE"]
 
-    requires    = "gtest/1.8.0@bincrafters/stable"
-    generators  = "cmake_find_package"
+    build_requires  = "gtest/1.8.0@bincrafters/stable"
+    generators      = "cmake_find_package"
 
     exports_sources = "include/*"
     no_copy_source = True


### PR DESCRIPTION
Since it's only needed to build and run the tests, and not during runtime.