### PR TITLE
Pass lambda parameter by const reference inside fmap/bind

### DIFF
--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -34,7 +34,7 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename A, typename B, typename... Rest>
     constexpr decltype(auto) bind(Nullable<A, Rest...> const& input, member::Mapper<const A, Nullable<B, Rest...>> mapper) noexcept {
-        return bind(input, [&mapper](auto value){ return std::invoke(mapper, value); });
+        return bind(input, [&mapper](auto const& value){ return std::invoke(mapper, value); });
     }
 
     /***

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -20,12 +20,13 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename UnaryFunction, typename A, typename... Rest>
     constexpr decltype(auto) bind(Nullable<A, Rest...> const& input, UnaryFunction mapper) noexcept {
+        using namespace nullable::syntax;
         using ResultT = decltype(mapper(std::declval<A>()));
-        if (nullable::syntax::empty<Nullable, A, Rest...>::_(input)) {
-            return nullable::syntax::make_empty<Nullable<A, Rest...>, ResultT>::_(input);
+        if (empty<Nullable, A, Rest...>::_(input)) {
+            return make_empty<Nullable<A, Rest...>, ResultT>::_(input);
         }
-        auto const value = nullable::syntax::value<Nullable, A, Rest...>::_(input);
-        return mapper(value);
+        auto const input_value = value<Nullable, A, Rest...>::_(input);
+        return mapper(input_value);
     }
 
     /***

--- a/include/absent/combinators/eval.h
+++ b/include/absent/combinators/eval.h
@@ -16,10 +16,11 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename NullaryFunction, typename A, typename... Rest>
     constexpr decltype(auto) eval(Nullable<A, Rest...> const& input, NullaryFunction fallback) noexcept {
-        if (nullable::syntax::empty<Nullable, A, Rest...>::_(input)) {
+        using namespace nullable::syntax;
+        if (empty<Nullable, A, Rest...>::_(input)) {
             return fallback();
         }
-        return nullable::syntax::value<Nullable, A, Rest...>::_(input);
+        return value<Nullable, A, Rest...>::_(input);
     }
 
 }

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -20,12 +20,13 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename UnaryFunction, typename A, typename... Rest>
     constexpr decltype(auto) fmap(Nullable<A, Rest...> const& input, UnaryFunction mapper) noexcept {
+        using namespace nullable::syntax;
         using ValueT = decltype(mapper(std::declval<A>()));
-        if (nullable::syntax::empty<Nullable, A, Rest...>::_(input)) {
-            return nullable::syntax::make_empty<Nullable<A, Rest...>, Nullable<ValueT, Rest...>>::_(input);
+        if (empty<Nullable, A, Rest...>::_(input)) {
+            return make_empty<Nullable<A, Rest...>, Nullable<ValueT, Rest...>>::_(input);
         }
-        auto const value = nullable::syntax::value<Nullable, A, Rest...>::_(input);
-        return nullable::syntax::make<Nullable, ValueT, Rest...>::_(mapper(value));
+        auto const input_value = value<Nullable, A, Rest...>::_(input);
+        return make<Nullable, ValueT, Rest...>::_(mapper(input_value));
     }
 
     /***

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -34,7 +34,7 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename A, typename B, typename... Rest>
     constexpr decltype(auto) fmap(Nullable<A, Rest...> const& input, member::Mapper<const A, B> mapper) noexcept {
-        return fmap(input, [&mapper](auto value){ return std::invoke(mapper, value); });
+        return fmap(input, [&mapper](auto const& value){ return std::invoke(mapper, value); });
     }
 
     /***

--- a/include/absent/combinators/foreach.h
+++ b/include/absent/combinators/foreach.h
@@ -15,8 +15,9 @@ namespace rvarago::absent {
      */
     template <template <typename...> typename Nullable, typename UnaryFunction, typename A, typename... Rest>
     constexpr auto foreach(Nullable<A, Rest...> const& input, UnaryFunction action) noexcept -> void {
-        if (!nullable::syntax::empty<Nullable, A, Rest...>::_(input)) {
-            action(nullable::syntax::value<Nullable, A, Rest...>::_(input));
+        using namespace nullable::syntax;
+        if (!empty<Nullable, A, Rest...>::_(input)) {
+            action(value<Nullable, A, Rest...>::_(input));
         }
     }
 


### PR DESCRIPTION
And simplify notation by importing namespace symbols inside functions.