### PR TITLE
refactor: Allow make_empty to be more general

### DIFF
--- a/include/absent/adapters/either.h
+++ b/include/absent/adapters/either.h
@@ -26,8 +26,9 @@ namespace rvarago::absent {
                 }
             };
 
-            template <typename A, typename B, typename E>
-            struct make_empty<std::variant<A, E>, std::variant<B, E>> final {
+            template <typename B, typename E>
+            struct make_empty<std::variant<B, E>> final {
+                template <typename A>
                 static constexpr auto _(std::variant<A, E> const& input) noexcept -> std::variant<B, E> {
                     return std::variant<B, E>{std::get<E>(input)};
                 }

--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -23,7 +23,7 @@ namespace rvarago::absent {
         using namespace nullable::syntax;
         using ResultT = decltype(mapper(std::declval<A>()));
         if (empty<Nullable, A, Rest...>::_(input)) {
-            return make_empty<Nullable<A, Rest...>, ResultT>::_(input);
+            return make_empty<ResultT>::_(input);
         }
         auto const input_value = value<Nullable, A, Rest...>::_(input);
         return mapper(input_value);

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -23,7 +23,7 @@ namespace rvarago::absent {
         using namespace nullable::syntax;
         using ValueT = decltype(mapper(std::declval<A>()));
         if (empty<Nullable, A, Rest...>::_(input)) {
-            return make_empty<Nullable<A, Rest...>, Nullable<ValueT, Rest...>>::_(input);
+            return make_empty<Nullable<ValueT, Rest...>>::_(input);
         }
         auto const input_value = value<Nullable, A, Rest...>::_(input);
         return make<Nullable, ValueT, Rest...>::_(mapper(input_value));

--- a/include/absent/nullable/syntax.h
+++ b/include/absent/nullable/syntax.h
@@ -39,10 +39,11 @@ namespace rvarago::absent::nullable::syntax {
     /**
      * For custom types that have a different concept of empty state.
      */
-    template <typename NullableIn, typename NullableOut>
+    template <typename Nullable>
     struct make_empty {
-        static constexpr auto _(NullableIn const&) noexcept -> NullableOut {
-            return NullableOut{};
+        template <typename... Args>
+        static constexpr auto _(Args&&...) noexcept -> Nullable {
+            return Nullable{};
         }
     };
 


### PR DESCRIPTION
Rather than assuming it always receive a nullable as an input.