### PR TITLE
Add convenient execution_status for multiple error handling

### DIFF
--- a/include/absent/combinators/bind.h
+++ b/include/absent/combinators/bind.h
@@ -34,7 +34,7 @@ constexpr decltype(auto) bind(Nullable<A, Rest...> const &input, UnaryFunction m
  */
 template <template <typename...> typename Nullable, typename A, typename B, typename... Rest>
 constexpr decltype(auto) bind(Nullable<A, Rest...> const &input,
-                              member::Mapper<const A, Nullable<B, Rest...>> mapper) noexcept {
+                              support::member_mapper<const A, Nullable<B, Rest...>> mapper) noexcept {
     return bind(input, [&mapper](auto const &value) { return std::invoke(mapper, value); });
 }
 
@@ -51,7 +51,7 @@ constexpr decltype(auto) operator>>(Nullable<A, Rest...> const &input, UnaryFunc
  */
 template <template <typename...> typename Nullable, typename A, typename B, typename... Rest>
 constexpr decltype(auto) operator>>(Nullable<A, Rest...> const &input,
-                                    member::Mapper<const A, Nullable<B, Rest...>> mapper) noexcept {
+                                    support::member_mapper<const A, Nullable<B, Rest...>> mapper) noexcept {
     return bind(input, mapper);
 }
 

--- a/include/absent/combinators/fmap.h
+++ b/include/absent/combinators/fmap.h
@@ -33,7 +33,7 @@ constexpr decltype(auto) fmap(Nullable<A, Rest...> const &input, UnaryFunction m
  * The same as fmap but for a member function that has to be const and parameterless.
  */
 template <template <typename...> typename Nullable, typename A, typename B, typename... Rest>
-constexpr decltype(auto) fmap(Nullable<A, Rest...> const &input, member::Mapper<const A, B> mapper) noexcept {
+constexpr decltype(auto) fmap(Nullable<A, Rest...> const &input, support::member_mapper<const A, B> mapper) noexcept {
     return fmap(input, [&mapper](auto const &value) { return std::invoke(mapper, value); });
 }
 
@@ -49,7 +49,8 @@ constexpr decltype(auto) operator|(Nullable<A, Rest...> const &input, Mapper map
  * Infix version of fmap for a member function.
  */
 template <template <typename...> typename Nullable, typename A, typename B, typename... Rest>
-constexpr decltype(auto) operator|(Nullable<A, Rest...> const &input, member::Mapper<const A, B> mapper) noexcept {
+constexpr decltype(auto) operator|(Nullable<A, Rest...> const &input,
+                                   support::member_mapper<const A, B> mapper) noexcept {
     return fmap(input, mapper);
 }
 

--- a/include/absent/support/execution_status.h
+++ b/include/absent/support/execution_status.h
@@ -1,0 +1,24 @@
+#ifndef RVARAGO_ABSENT_EXECUTIONSTATUS_H
+#define RVARAGO_ABSENT_EXECUTIONSTATUS_H
+
+#include "absent/support/blank.h"
+#include <optional>
+
+namespace rvarago::absent::support {
+/**
+ * Type for a computation that may or may not succeed.
+ */
+using execution_status = std::optional<blank>;
+
+/**
+ * For a successful computation.
+ */
+inline constexpr execution_status success = std::make_optional(unit);
+
+/**
+ * For a failed computation.
+ */
+inline constexpr execution_status failure = std::nullopt;
+}
+
+#endif

--- a/include/absent/support/member.h
+++ b/include/absent/support/member.h
@@ -1,9 +1,9 @@
 #ifndef RVARAGO_ABSENT_MEMBER_H
 #define RVARAGO_ABSENT_MEMBER_H
 
-namespace rvarago::absent::member {
+namespace rvarago::absent::support {
 template <typename A, typename B>
-using Mapper = B (A::*)() const;
+using member_mapper = B (A::*)() const;
 }
 
 #endif // RVARAGO_ABSENT_MEMBER_H

--- a/tests/bind_test.cpp
+++ b/tests/bind_test.cpp
@@ -1,5 +1,5 @@
 #include <absent/combinators/bind.h>
-#include <absent/support/blank.h>
+#include <absent/support/execution_status.h>
 #include <absent/support/sink.h>
 
 #include <optional>
@@ -78,17 +78,17 @@ SCENARIO("bind provides a generic and type-safe way to map and then flat a nulla
                 CHECK((some_person >> &Person::id_as_none) == std::nullopt);
             }
         }
-        AND_GIVEN("bind used for chaining parameterless functions") {
+        AND_GIVEN("bind used for multiple error handling") {
 
             bool is_set = false;
-            auto set_flag = [&is_set] {
+            auto set_flag = [&is_set]() -> support::execution_status {
                 is_set = true;
-                return std::make_optional(support::unit);
+                return support::success;
             };
 
-            WHEN("when first is empty") {
+            WHEN("when initial nullable is empty/failed") {
 
-                std::optional<int> const none;
+                support::execution_status const none = support::failure;
 
                 THEN("do nothing and return an empty nullable to stop the chaining") {
 
@@ -99,9 +99,9 @@ SCENARIO("bind provides a generic and type-safe way to map and then flat a nulla
                 }
             }
 
-            WHEN("when first is not empty") {
+            WHEN("when initial nullable is not empty/failed") {
 
-                auto const some = std::optional{1};
+                support::execution_status const some = support::success;
 
                 THEN("run the function that triggers a side-effect and return a non-empty nullable") {
 


### PR DESCRIPTION
* feature: Add convenient execution_status for multiple error handling
    
    The header `absent/support/execution_status.h` conveniently,
    exports the alias `execution_status` for `std::optional<blank>`, as well
    as the compile-time constants of type `execution_status`:
    
    * `success` for an `execution_status` filled with a `unit`.
    * `failure` for an `execution_status` filled with a `std::nullopt`.

* refactor: Move member mapper into the namespace support
    
    And rename it to member_mapper.