### PR TITLE
Rename attempt::run to attempt::or_catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ which shall be empty if the exception was thrown or shall contain the returned v
 this sole purpose, _absent_ provides a combinator called `attempt`:
 
 ```
-auto const result = attempt<std::optional>::run<std::logic_error>(may_throw_an_exception);
+auto const result = attempt<std::optional>::or_catch<std::logic_error>(may_throw_an_exception);
 ```
 
 Where `may_throw_an_exception` has the following signature:

--- a/include/absent/combinators/attempt.h
+++ b/include/absent/combinators/attempt.h
@@ -11,7 +11,7 @@ template <template <typename...> typename Nullable, typename... Rest>
 struct attempt {
 
     template <typename BaseException = std::exception, typename NullaryFunction>
-    static auto run(NullaryFunction unsafe) -> Nullable<decltype(unsafe()), Rest...> {
+    static auto or_catch(NullaryFunction unsafe) -> Nullable<decltype(unsafe()), Rest...> {
         using namespace nullable::syntax;
         using ValueT = decltype(unsafe());
         try {

--- a/include/absent/support/sink.h
+++ b/include/absent/support/sink.h
@@ -11,9 +11,9 @@ namespace rvarago::absent::support {
  * @param f callable to be wrapped.
  * @return a new callable that discards the parameters sent to it.
  */
-template <typename UnaryFunction>
-constexpr decltype(auto) sink(UnaryFunction &&f) noexcept {
-    return [f = std::forward<UnaryFunction>(f)](auto &&...) { return f(); };
+template <typename NullaryFunction>
+constexpr decltype(auto) sink(NullaryFunction &&f) noexcept {
+    return [f = std::forward<NullaryFunction>(f)](auto &&...) { return f(); };
 }
 
 }

--- a/tests/attempt_test.cpp
+++ b/tests/attempt_test.cpp
@@ -19,14 +19,14 @@ SCENARIO("attempt provides a generic and type-safe way to wrap an exception into
 
             AND_WHEN("exception is of expected type") {
                 THEN("return a new empty nullable") {
-                    auto const empty = attempt<std::optional>::run(throw_runtime_error);
+                    auto const empty = attempt<std::optional>::or_catch(throw_runtime_error);
                     CHECK(empty == std::nullopt);
                 }
             }
 
             AND_WHEN("exception is not of expected type") {
                 THEN("propagate the exception previously thrown") {
-                    CHECK_THROWS_AS(attempt<std::optional>::run<std::logic_error>(throw_runtime_error),
+                    CHECK_THROWS_AS(attempt<std::optional>::or_catch<std::logic_error>(throw_runtime_error),
                                     std::runtime_error);
                 }
             }
@@ -37,7 +37,7 @@ SCENARIO("attempt provides a generic and type-safe way to wrap an exception into
             auto never_throw = []() -> int { return 42; };
 
             THEN("return the result inside a non-empty nullable") {
-                auto const success = attempt<std::optional>::run(never_throw);
+                auto const success = attempt<std::optional>::or_catch(never_throw);
                 CHECK(success == std::optional{42});
             }
         }

--- a/tests/either_test.cpp
+++ b/tests/either_test.cpp
@@ -76,7 +76,7 @@ SCENARIO("either lawfully works as a nullable", "[either]") {
                 auto always_throw = []() -> int { throw std::runtime_error{"failed"}; };
 
                 THEN("return a new failed either") {
-                    auto const failed = attempt<either, std::exception>::run(always_throw);
+                    auto const failed = attempt<either, std::exception>::or_catch(always_throw);
                     expect_alternative_of_type<std::exception>(failed);
                 }
             }
@@ -86,7 +86,7 @@ SCENARIO("either lawfully works as a nullable", "[either]") {
                 auto never_throw = []() -> int { return 42; };
 
                 THEN("return the result inside a non-failed either") {
-                    auto const success = attempt<either, std::exception>::run(never_throw);
+                    auto const success = attempt<either, std::exception>::or_catch(never_throw);
                     expect_alternative_of_type<int>(success);
                     CHECK(std::get<int>(success) == 42);
                 }


### PR DESCRIPTION
*  change: Rename attempt::run to attempt::or_catch
To better reflect its purpose.

* refactor: Rename type for callable wrapped by sink to NullaryFunction