### PR TITLE
Makefile: Use $() instead of ${} to access variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,34 +9,34 @@ BUILD_TYPE              = Debug
 all: compile
 
 env:
-	docker build -t ${PROJECT_NAME} .
+	docker build -t $(PROJECT_NAME) .
 
 env-format-check: env
-	docker run --rm ${PROJECT_NAME} make format-check --no-print-directory
+	docker run --rm $(PROJECT_NAME) make format-check --no-print-directory
 
 env-test: env
-	docker run --rm ${PROJECT_NAME} make compile test --no-print-directory
+	docker run --rm $(PROJECT_NAME) make compile test --no-print-directory
 
 install:
-	cd ${BUILD_DIR} && cmake --build . --target install
+	cd $(BUILD_DIR) && cmake --build . --target install
 
 test:
-	cd ${BUILD_DIR} && ctest -VV .
+	cd $(BUILD_DIR) && ctest -VV .
 
 compile: gen
-	cd ${BUILD_DIR} && cmake --build .
+	cd $(BUILD_DIR) && cmake --build .
 
 gen: dep
-	cd ${BUILD_DIR} && cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DBUILD_TESTS=${BUILD_TESTS} ..
+	cd $(BUILD_DIR) && cmake -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DBUILD_TESTS=$(BUILD_TESTS) ..
 
 dep: mk
-	cd ${BUILD_DIR} && conan install .. --build=missing -pr ${PROFILE} -s build_type=${BUILD_TYPE}
+	cd $(BUILD_DIR) && conan install .. --build=missing -pr $(PROFILE) -s build_type=$(BUILD_TYPE)
 
 mk:
-	mkdir -p ${BUILD_DIR}
+	mkdir -p $(BUILD_DIR)
 
 clean:
-	rm -rf ${BUILD_DIR}
+	rm -rf $(BUILD_DIR)
 
 format-check:
 	@if git ls-files -- '*.cpp' '*.h' | xargs clang-format -style=file -output-replacements-xml | grep -q "<replacement "; then \


### PR DESCRIPTION
Because it's a more common syntax.