### PR TITLE
change: Drop special overloads for non-static member functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/rvarago/absent.svg?branch=master)](https://travis-ci.org/rvarago/absent)
 
+[![Build Status](https://dev.azure.com/rvarago/absent/_apis/build/status/rvarago.absent?branchName=master)](https://dev.azure.com/rvarago/absent/_build/latest?definitionId=1&branchName=master)
+
 This is a small header-only library meant to simplify the composition of nullable types in a declarative style for some C++ types constructors.
 
 _absent_ provides an alternative way to solve a very specific problem of chaining operations on nullable types.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # absent
 
-This is a small header-only library meant to simplify the composition of nullable types in a declarative style for some C++ types constructors.
-
 [![Build Status](https://travis-ci.org/rvarago/absent.svg?branch=master)](https://travis-ci.org/rvarago/absent)
 
-## A word of caution
+This is a small header-only library meant to simplify the composition of nullable types in a declarative style for some C++ types constructors.
 
-_absent_ provides an alternative way to solve a very specific problem of enabling some kinds of compositions for some kinds of nullable types. Of course, there are several ways to do achieve pretty much the same goal.
+_absent_ provides an alternative way to solve a very specific problem of chaining operations on nullable types.
 
 _absent_ represents a tiny contribution that aims to leverage composition via immutable operations that don't mutate the argument, instead, they create and return brand new instances.
 
 It may be a pro, because by restricting mutation the likelihood of introducing a class of bugs may be reduced as well.
 
-However, it may also be a con, because for each operation a new instance is created and then destroyed. Hopefully, few copies would be optimized away by the compiler, but there's no guarantee. So it's important to keep this in mind, maybe via objective measurements that prove that it's a real problem for the specific project in which _absent_ is planned to be used.
+However, it may also be a con, because for each operation a new instance is usually created and then destroyed.
+Hopefully, few copies would be optimized away by the compiler, but there's no guarantee. So it's important to keep this in mind, maybe via objective measurements that prove that it's a real problem for the specific project in which _absent_ is planned to be used.
 
 ## Description
 
@@ -42,8 +41,10 @@ auto const zip_code = zip_code(maybe_address.value());
 We have mixed business logic with error handling, it'd be nice to have these two concerns apart from each other. It's a lot
 of boilerplate to achieve such a simple requirement as obtaining the zip code of a given person.
 
-Furthermore, we have to make several calls to `std::optional<T>` accessor member function, `value()`, and for each call, we have to make sure we’ve checked that it's not empty before accessing its value.
-Otherwise, it would trigger a `bad_optional_access`. Thus, it’d be nice to minimize the direct calls to `value()` by wrapping intermediary ones inside a function that does the checking and then accesses the value.
+Furthermore, we have to make several calls to `std::optional<T>` accessor member function, `value()`, and for each call,
+we have to make sure we’ve checked that it's not empty before accessing its value.
+Otherwise, it would trigger a `bad_optional_access`. Thus, it’d be nice to minimize the direct calls to `value()` by
+wrapping intermediary ones inside a function that does the checking and then accesses the value.
 And only make the direct call to `value()` from our code at the very end of the composition.
 
 **Note:**  We could have used the dereference operator `*` rather than `value()`. It would invoke undefined behaviour instead of
@@ -93,7 +94,7 @@ expressiveness achieved by composing simple functions as we can do for non-nulla
 
 ### Enters _absent_
 
-_absent_ provides simple abstractions based on functional programming to help us composing operations. It's inspired by
+_absent_ provides simple abstractions based on functional programming to help us to compose operations. It's inspired by
 Haskell and so uses a similar vocabulary. It does **NOT** attempt to solve all problems when it comes to the complex problem of error-handling,
 far away from it.
 
@@ -160,21 +161,17 @@ Which is very similar to the notation used to express the pipeline:
 Almost as easy to read as the version without using nullable types (maybe even more?) and with the expressiveness and type-safety
 brought by them.
 
-In the case where `find_address` and `zip_code` are "getter" member functions, such as:
+In the case where `find_address` and `zip_code` are non-static member functions, such as:
 
 ```
 std::optional<address> person::find_address() const;
 zip address::zip_code() const;
 ```
 
-It's possible to wrap them inside lambdas and use `transform` and `and_then` as we did before.
-
-However, overloads that accept getter member functions are also provided to simplify the caller code even more.
-
-So, using the infix notation, we can do:
+It's possible to wrap them inside std::mem_fn, lambdas, etc, and use `transform` and `and_then` as we did before. For instance:
 
 ```
-auto const maybe_zip_code = find_person() >> &person::find_address | &address::zip_code;
+auto const maybe_zip_code = find_person() >> std::mem_fn(&person::find_address) | std::mem_fn(&address::zip_code);
 if (maybe_zip_code) {
     // You just have to check at the end before making the "final" use of the outcome yielded by the composition chain
 }
@@ -213,22 +210,6 @@ std::optional<std::string> const mapped_some_of_zero_as_string = some_zero_as_st
                                                                     | int2string; // contains "0"
 ```
 
-There's also an overload for `transform` that accepts a member function that has to be **const** and **parameterless** getter function.
-So you can do this:
-
-```
-struct person {
-    int id() const{ return 1; }
-};
-auto const maybe_id = std::optional{person{}} | &person::id; // contains 1
-```
-
-Which calls `id()` if the `std::optional<person>` contains a `person` and wraps it inside a new `std::optional<int>`.
-Otherwise, in case the `std::optional<person>` does not contain a `person` it simply returns an empty `std::optional<int>`.
-
-It's also possible to use the non-member overload for `transform`, but at the call site, the user has to wrap the member
-function inside a lambda, which adds a little bit of noise to the caller code.
-
 #### and_then (>>)
 
 Another useful combinator is `and_then` which allows the composition of functions which by themselves also return values
@@ -265,22 +246,6 @@ std::optional<std::string> const mapped_some_of_zero_as_string = some_zero_as_st
                                                                     >> maybe_string2int
                                                                     >> maybe_int2string; // contains "0"
 ```
-
-Similarly to `transform`, there's also an overload for `and_then` that accepts a member function that has to be **const** and
-**parameterless** getter function. So you can do this:
-
-```
-struct person {
-     std::optional<int> id() const{ return 1; }
-};
-auto const maybe_id = std::optional{person{}} >> &person::id;
-```
-
-Which calls `id()` if the `std::optional<person>` contains a `person` already wrapped in an `std::optional<int>`.
-Otherwise, in case the `std::optional<person>` does not contain a `person` it simply returns an empty `std::optional<int>`.
-
-It's also possible to use the non-member overload for `and_then`, but at the call site, the user has to wrap the member
-function inside a lambda, which adds a little bit of noise to the caller code.
 
 ##### Multiple error handling
 
@@ -430,10 +395,10 @@ Or it throws an exception derived from `std::logic_error`, in which case `result
 
 ### Optional
 
-* CMake (_only if you need to build from sources_)
-* Make (_only if you want to use it to orchestrate task execution_)
-* Conan (_only if you want generate a package or build the tests using conan as a provider for the test framework_)
-* Docker (_only if you want build from inside a docker container_)
+* CMake
+* Make
+* Conan
+* Docker
 
 ## Build
 

--- a/include/absent/adapters/either/and_then.h
+++ b/include/absent/adapters/either/and_then.h
@@ -1,11 +1,9 @@
 #ifndef RVARAGO_ABSENT_ADAPTERS_EITHER_ANDTHEN_H
 #define RVARAGO_ABSENT_ADAPTERS_EITHER_ANDTHEN_H
 
-#include <functional>
 #include <utility>
 
 #include "absent/adapters/either/either.h"
-#include "absent/support/member.h"
 
 namespace rvarago::absent::adapters::either {
 
@@ -37,24 +35,6 @@ template <typename A, typename E, typename UnaryFunction>
 constexpr auto operator>>(types::either<A, E> const &input, UnaryFunction &&mapper) noexcept
     -> decltype(std::declval<UnaryFunction>()(std::declval<A>())) {
     return and_then(input, std::forward<UnaryFunction>(mapper));
-}
-
-/***
- * The same as and_then but for a member function that has to be const and parameterless.
- */
-template <typename A, typename E, typename B>
-constexpr auto and_then(types::either<A, E> const &input,
-                        support::member_mapper<const A, types::either<B, E>> mapper) noexcept -> types::either<B, E> {
-    return and_then(input, [&mapper](auto const &value) { return std::invoke(mapper, value); });
-}
-
-/**
- * Infix version of and_then for a member function.
- */
-template <typename A, typename E, typename B>
-constexpr auto operator>>(types::either<A, E> const &input,
-                          support::member_mapper<const A, types::either<B, E>> mapper) noexcept -> types::either<B, E> {
-    return and_then(input, mapper);
 }
 
 }

--- a/include/absent/adapters/either/transform.h
+++ b/include/absent/adapters/either/transform.h
@@ -1,11 +1,9 @@
 #ifndef RVARAGO_ABSENT_ADAPTERS_EITHER_TRANSFORM_H
 #define RVARAGO_ABSENT_ADAPTERS_EITHER_TRANSFORM_H
 
-#include <functional>
 #include <utility>
 
 #include "absent/adapters/either/either.h"
-#include "absent/support/member.h"
 
 namespace rvarago::absent::adapters::either {
 
@@ -36,24 +34,6 @@ template <typename A, typename E, typename UnaryFunction>
 constexpr auto operator|(types::either<A, E> const &input, UnaryFunction &&mapper) noexcept
     -> types::either<decltype(std::declval<UnaryFunction>()(std::declval<A>())), E> {
     return transform(input, std::forward<UnaryFunction>(mapper));
-}
-
-/***
- * The same as transform but for a member function that has to be const and parameterless.
- */
-template <typename A, typename E, typename B>
-constexpr auto transform(types::either<A, E> const &input, support::member_mapper<const A, B> mapper) noexcept
-    -> types::either<B, E> {
-    return transform(input, [&mapper](auto const &value) { return std::invoke(mapper, value); });
-}
-
-/**
- * Infix version of transform for a member function.
- */
-template <typename A, typename E, typename B>
-constexpr auto operator|(types::either<A, E> const &input, support::member_mapper<const A, B> mapper) noexcept
-    -> types::either<B, E> {
-    return transform(input, mapper);
 }
 
 }

--- a/include/absent/and_then.h
+++ b/include/absent/and_then.h
@@ -1,10 +1,7 @@
 #ifndef RVARAGO_ABSENT_ANDTHEN_H
 #define RVARAGO_ABSENT_ANDTHEN_H
 
-#include <functional>
 #include <utility>
-
-#include "absent/support/member.h"
 
 namespace rvarago::absent {
 
@@ -35,24 +32,6 @@ template <template <typename> typename Nullable, typename UnaryFunction, typenam
 constexpr auto operator>>(Nullable<A> const &input, UnaryFunction &&mapper) noexcept
     -> decltype(std::declval<UnaryFunction>()(std::declval<A>())) {
     return and_then(input, std::forward<UnaryFunction>(mapper));
-}
-
-/***
- * The same as and_then but for a member function that has to be const and parameterless.
- */
-template <template <typename> typename Nullable, typename A, typename B>
-constexpr auto and_then(Nullable<A> const &input, support::member_mapper<const A, Nullable<B>> mapper) noexcept
-    -> Nullable<B> {
-    return and_then(input, [&mapper](auto const &value) { return std::invoke(mapper, value); });
-}
-
-/***
- * Infix version of and_then for a member function.
- */
-template <template <typename> typename Nullable, typename A, typename B>
-constexpr auto operator>>(Nullable<A> const &input, support::member_mapper<const A, Nullable<B>> mapper) noexcept
-    -> Nullable<B> {
-    return and_then(input, mapper);
 }
 
 }

--- a/include/absent/support/member.h
+++ b/include/absent/support/member.h
@@ -1,9 +1,0 @@
-#ifndef RVARAGO_ABSENT_SUPPORT_MEMBER_H
-#define RVARAGO_ABSENT_SUPPORT_MEMBER_H
-
-namespace rvarago::absent::support {
-template <typename A, typename B>
-using member_mapper = B (A::*)() const;
-}
-
-#endif

--- a/include/absent/transform.h
+++ b/include/absent/transform.h
@@ -1,10 +1,7 @@
 #ifndef RVARAGO_ABSENT_TRANSFORM_H
 #define RVARAGO_ABSENT_TRANSFORM_H
 
-#include <functional>
 #include <utility>
-
-#include "absent/support/member.h"
 
 namespace rvarago::absent {
 
@@ -34,22 +31,6 @@ template <template <typename> typename Nullable, typename A, typename UnaryFunct
 constexpr auto operator|(Nullable<A> const &input, UnaryFunction &&mapper) noexcept
     -> Nullable<decltype(std::declval<UnaryFunction>()(std::declval<A>()))> {
     return transform(input, std::forward<UnaryFunction>(mapper));
-}
-
-/***
- * The same as transform but for a member function that has to be const and parameterless.
- */
-template <template <typename> typename Nullable, typename A, typename B>
-constexpr auto transform(Nullable<A> const &input, support::member_mapper<const A, B> mapper) noexcept -> Nullable<B> {
-    return transform(input, [&mapper](auto const &value) { return std::invoke(mapper, value); });
-}
-
-/**
- * Infix version of transform for a member function.
- */
-template <template <typename> typename Nullable, typename A, typename B>
-constexpr auto operator|(Nullable<A> const &input, support::member_mapper<const A, B> mapper) noexcept -> Nullable<B> {
-    return transform(input, mapper);
 }
 
 }

--- a/tests/and_then_test.cpp
+++ b/tests/and_then_test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -49,7 +50,7 @@ SCENARIO("and_then provides a way to and_then {optional<A>, f: A -> optional<B>}
                 std::optional<Person> none;
 
                 THEN("return a new empty optional<string>") {
-                    std::optional<std::string> bound_none = none >> &Person::id;
+                    std::optional<std::string> bound_none = none >> std::mem_fn(&Person::id);
                     CHECK(bound_none == std::nullopt);
                 }
             }
@@ -58,7 +59,7 @@ SCENARIO("and_then provides a way to and_then {optional<A>, f: A -> optional<B>}
                 std::optional<Person> some{Person{}};
 
                 THEN("return a non-empty and bound optional<string>") {
-                    std::optional<std::string> bound_some = some >> &Person::id;
+                    std::optional<std::string> bound_some = some >> std::mem_fn(&Person::id);
                     CHECK(bound_some == std::optional{std::string{"200"}});
                 }
             }

--- a/tests/either/and_then_test.cpp
+++ b/tests/either/and_then_test.cpp
@@ -1,4 +1,4 @@
-
+#include <functional>
 #include <string>
 
 #include <catch2/catch.hpp>
@@ -62,7 +62,7 @@ SCENARIO("and_then provides a way to map {either<A, E>, f: A -> either<B, E>} to
                 either<Person, Error> invalid{Error{"404"}};
 
                 THEN("return a new invalid either<string, Error>") {
-                    either<std::string, Error> bound_invalid = invalid >> &Person::id;
+                    either<std::string, Error> bound_invalid = invalid >> std::mem_fn(&Person::id);
                     CHECK(bound_invalid == either<std::string, Error>{Error{"404"}});
                 }
             }
@@ -71,7 +71,7 @@ SCENARIO("and_then provides a way to map {either<A, E>, f: A -> either<B, E>} to
                 either<Person, Error> valid{Person{}};
 
                 THEN("return a valid and bound either<string, Error>>") {
-                    either<std::string, Error> bound_valid = valid >> &Person::id;
+                    either<std::string, Error> bound_valid = valid >> std::mem_fn(&Person::id);
                     CHECK(bound_valid == either<std::string, Error>{std::string{"200"}});
                 }
             }

--- a/tests/either/transform_test.cpp
+++ b/tests/either/transform_test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -60,7 +61,7 @@ SCENARIO("transform provides a way to map {either<A, E>, f: A -> B} to either<B,
                 either<Person, Error> invalid{Error{"404"}};
 
                 THEN("return a new invalid either<string, Error>") {
-                    either<std::string, Error> mapped_invalid = invalid | &Person::id;
+                    either<std::string, Error> mapped_invalid = invalid | std::mem_fn(&Person::id);
                     CHECK(mapped_invalid == either<std::string, Error>{Error{"404"}});
                 }
             }
@@ -69,7 +70,7 @@ SCENARIO("transform provides a way to map {either<A, E>, f: A -> B} to either<B,
                 either<Person, Error> valid{Person{}};
 
                 THEN("return a valid and mapped either<string, Error>") {
-                    either<std::string, Error> mapped_valid = valid | &Person::id;
+                    either<std::string, Error> mapped_valid = valid | std::mem_fn(&Person::id);
                     CHECK(mapped_valid == either<std::string, Error>{std::string{"200"}});
                 }
             }

--- a/tests/transform_test.cpp
+++ b/tests/transform_test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -49,7 +50,7 @@ SCENARIO("transform provides a way to map {optional<A>, f: A -> B} to optional<B
                 std::optional<Person> none;
 
                 THEN("return a new empty optional<string>") {
-                    std::optional<std::string> mapped_none = none | &Person::id;
+                    std::optional<std::string> mapped_none = none | std::mem_fn(&Person::id);
                     CHECK(mapped_none == std::nullopt);
                 }
             }
@@ -58,7 +59,7 @@ SCENARIO("transform provides a way to map {optional<A>, f: A -> B} to optional<B
                 std::optional<Person> some{Person{}};
 
                 THEN("return a non-empty and mapped optional<string>") {
-                    std::optional<std::string> mapped_some = some | &Person::id;
+                    std::optional<std::string> mapped_some = some | std::mem_fn(&Person::id);
                     CHECK(mapped_some == std::optional{std::string{"200"}});
                 }
             }


### PR DESCRIPTION
*  change: Drop special overloads for non-static member functions

Instead of having more overloads with little benefit, it's better to
keep it simpler and smaller, and use the facilities already provided
by the language, for instance, std::mem_fn or lambdas.

* docs: Add status badge for Azure Pipelines 