### PR TITLE
feature: Add new operation to extract a variant into a nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,17 @@ int may_throw_an_exception();
 So it returns either value of type `int`, in which case `result` will be an `std::optional<int>` that wraps the returned value.
 Or it throws an exception derived from `std::logic_error`, in which case `result` will be an empty `std::optional<int>`.
 
+#### from_variant
+
+`from_variant` allows us to go from an `std::variant<As...>` to a nullable type, such as `std::optional<A>`, holding the value
+of type `A` if the variant holds a value of such type, or empty otherwise.
+
+```
+std::variant<int, std::string> v = 10;
+std::optional<int> opt = from_variant<int>(v);
+```
+
+
 ## Requirements
 
 ### Mandatory

--- a/include/absent/adapters/either/and_then.h
+++ b/include/absent/adapters/either/and_then.h
@@ -22,10 +22,10 @@ template <typename A, typename E, typename UnaryFunction>
 constexpr auto and_then(types::either<A, E> const &input, UnaryFunction &&mapper) noexcept
     -> decltype(std::declval<UnaryFunction>()(std::declval<A>())) {
     using EitherB = decltype(mapper(std::declval<A>()));
-    if (!std::holds_alternative<A>(input)) {
-        return EitherB{std::get<E>(input)};
+    if (auto const p = std::get_if<A>(&input); p) {
+        return std::forward<UnaryFunction>(mapper)(*p);
     }
-    return std::forward<UnaryFunction>(mapper)(std::get<A>(input));
+    return EitherB{std::get<E>(input)};
 }
 
 /***

--- a/include/absent/adapters/either/for_each.h
+++ b/include/absent/adapters/either/for_each.h
@@ -17,10 +17,9 @@ namespace rvarago::absent::adapters::either {
  */
 template <typename UnaryFunction, typename A, typename E>
 constexpr auto for_each(types::either<A, E> const &input, UnaryFunction &&action) noexcept -> void {
-    if (!std::holds_alternative<A>(input)) {
-        return;
+    if (auto const p = std::get_if<A>(&input); p) {
+        std::forward<UnaryFunction>(action)(*p);
     }
-    std::forward<UnaryFunction>(action)(std::get<A>(input));
 }
 
 }

--- a/include/absent/adapters/either/transform.h
+++ b/include/absent/adapters/either/transform.h
@@ -21,10 +21,10 @@ template <typename A, typename E, typename UnaryFunction>
 constexpr auto transform(types::either<A, E> const &input, UnaryFunction &&mapper) noexcept
     -> types::either<decltype(std::declval<UnaryFunction>()(std::declval<A>())), E> {
     using EitherB = types::either<decltype(mapper(std::declval<A>())), E>;
-    if (!std::holds_alternative<A>(input)) {
-        return EitherB{std::get<E>(input)};
+    if (auto const p = std::get_if<A>(&input); p) {
+        return EitherB{std::forward<UnaryFunction>(mapper)(*p)};
     }
-    return EitherB{std::forward<UnaryFunction>(mapper)(std::get<A>(input))};
+    return EitherB{std::get<E>(input)};
 }
 
 /***

--- a/include/absent/support/from_variant.h
+++ b/include/absent/support/from_variant.h
@@ -1,0 +1,27 @@
+#ifndef RVARAGO_ABSENT_FROMVARIANT_H
+#define RVARAGO_ABSENT_FROMVARIANT_H
+
+#include <optional>
+#include <variant>
+
+namespace rvarago::absent {
+
+/***
+ * Given a nullable type N<A> (i.e. optional like object), and a variant<As....>
+ * - When A is the same held by the variant: it should return a nullable N<A> wrapping the corresponding value.
+ * - When *not*: it should return a new empty nullable N<A>.
+ *
+ * @param input an std::variant.
+ * @return a new nullable containing the value wrapped by the variant, possibly empty.
+ */
+template <typename A, template <typename> typename Nullable = std::optional, typename... Rest>
+constexpr auto from_variant(std::variant<Rest...> v) noexcept -> Nullable<A> {
+    if (auto const value = std::get_if<A>(&v); value) {
+        return Nullable<A>{*value};
+    }
+    return Nullable<A>{};
+}
+
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${PROJECT_NAME}
         either/for_each_test.cpp
 
         execution_status_test.cpp
+        from_variant_test.cpp
 
         main.cpp
 )

--- a/tests/from_variant_test.cpp
+++ b/tests/from_variant_test.cpp
@@ -1,0 +1,35 @@
+#include <string>
+
+#include <catch2/catch.hpp>
+
+#include <absent/support/from_variant.h>
+
+using namespace rvarago::absent;
+
+SCENARIO("from_variant provides a way to go from a variant<Rest..> to optional<A>", "[from_variant]") {
+
+    GIVEN("A variant<int, string>") {
+
+        std::variant<int, std::string> variant;
+
+        WHEN("in the unexpected string alternative") {
+
+            variant = std::string{"404"};
+
+            THEN("return an empty optional<int>") {
+                std::optional<int> none = from_variant<int>(variant);
+                CHECK(none == std::nullopt);
+            }
+        }
+
+        WHEN("in the expected int alternative") {
+
+            variant = 42;
+
+            THEN("return a non-empty optional<int> wrapping the obtained int") {
+                std::optional<int> some = from_variant<int>(variant);
+                CHECK(some == std::optional<int>{42});
+            }
+        }
+    }
+}


### PR DESCRIPTION
* feature: Add new supporting operation from_variant
    
    That allows the conversion from std::variant<As..> to std::optional<A>
    (or any other type that models the nullable concept).

* refactor: Implement either combinators in terms of get_if
    
    It yields a simpler code.
