### PR TITLE
feat: Support generic callables with std::invoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 build
 .idea
+.vscode

--- a/include/absent/adapters/either/and_then.h
+++ b/include/absent/adapters/either/and_then.h
@@ -3,6 +3,7 @@
 
 #include "absent/adapters/either/either.h"
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent::adapters::either {
@@ -20,13 +21,15 @@ namespace rvarago::absent::adapters::either {
  */
 template <typename A, typename E, typename UnaryFunction>
 constexpr auto and_then(types::either<A, E> const &input,
-                        UnaryFunction &&mapper) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> decltype(std::declval<UnaryFunction>()(std::declval<A>())) {
-    using EitherB = decltype(mapper(std::declval<A>()));
+                        UnaryFunction &&mapper) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                              std::declval<A>())))
+    -> decltype(std::invoke(std::declval<UnaryFunction>(), std::declval<A>())) {
+    using EitherB = decltype(std::invoke(mapper, std::declval<A>()));
     if (auto const p = std::get_if<A>(&input); p) {
-        return std::forward<UnaryFunction>(mapper)(*p);
+        return std::invoke(std::forward<UnaryFunction>(mapper), *p);
+    } else {
+        return EitherB{std::get<E>(input)};
     }
-    return EitherB{std::get<E>(input)};
 }
 
 /***
@@ -34,8 +37,9 @@ constexpr auto and_then(types::either<A, E> const &input,
  */
 template <typename A, typename E, typename UnaryFunction>
 constexpr auto operator>>(types::either<A, E> const &input,
-                          UnaryFunction &&mapper) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> decltype(std::declval<UnaryFunction>()(std::declval<A>())) {
+                          UnaryFunction &&mapper) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                                std::declval<A>())))
+    -> decltype(std::invoke(std::declval<UnaryFunction>(), std::declval<A>())) {
     return and_then(input, std::forward<UnaryFunction>(mapper));
 }
 

--- a/include/absent/adapters/either/and_then.h
+++ b/include/absent/adapters/either/and_then.h
@@ -1,9 +1,9 @@
 #ifndef RVARAGO_ABSENT_ADAPTERS_EITHER_ANDTHEN_H
 #define RVARAGO_ABSENT_ADAPTERS_EITHER_ANDTHEN_H
 
-#include <utility>
-
 #include "absent/adapters/either/either.h"
+
+#include <utility>
 
 namespace rvarago::absent::adapters::either {
 

--- a/include/absent/adapters/either/attempt.h
+++ b/include/absent/adapters/either/attempt.h
@@ -1,10 +1,10 @@
 #ifndef RVARAGO_ABSENT_ADAPTERS_EITHER_ATTEMPT_H
 #define RVARAGO_ABSENT_ADAPTERS_EITHER_ATTEMPT_H
 
+#include "absent/adapters/either/either.h"
+
 #include <exception>
 #include <utility>
-
-#include "absent/adapters/either/either.h"
 
 namespace rvarago::absent::adapters::either {
 

--- a/include/absent/adapters/either/attempt.h
+++ b/include/absent/adapters/either/attempt.h
@@ -4,6 +4,7 @@
 #include "absent/adapters/either/either.h"
 
 #include <exception>
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent::adapters::either {
@@ -18,10 +19,11 @@ namespace rvarago::absent::adapters::either {
  * @return a new nullable wrapping the value returned by unsafe, possibly invalid if unsafe threw.
  */
 template <typename BaseException = std::exception, typename NullaryFunction>
-auto attempt(NullaryFunction &&unsafe) -> types::either<decltype(std::declval<NullaryFunction>()()), BaseException> {
-    using EitherA = types::either<decltype(unsafe()), BaseException>;
+auto attempt(NullaryFunction &&unsafe)
+    -> types::either<decltype(std::invoke(std::declval<NullaryFunction>())), BaseException> {
+    using EitherA = types::either<decltype(std::invoke(unsafe)), BaseException>;
     try {
-        return EitherA{std::forward<NullaryFunction>(unsafe)()};
+        return EitherA{std::invoke(std::forward<NullaryFunction>(unsafe))};
     } catch (BaseException const &ex) {
         return EitherA{ex};
     }

--- a/include/absent/adapters/either/eval.h
+++ b/include/absent/adapters/either/eval.h
@@ -1,9 +1,9 @@
 #ifndef RVARAGO_ABSENT_ADAPTERS_EITHER_EVAL_H
 #define RVARAGO_ABSENT_ADAPTERS_EITHER_EVAL_H
 
-#include <utility>
-
 #include "absent/adapters/either/either.h"
+
+#include <utility>
 
 namespace rvarago::absent::adapters::either {
 

--- a/include/absent/adapters/either/eval.h
+++ b/include/absent/adapters/either/eval.h
@@ -3,6 +3,7 @@
 
 #include "absent/adapters/either/either.h"
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent::adapters::either {
@@ -18,11 +19,12 @@ namespace rvarago::absent::adapters::either {
  */
 template <typename NullaryFunction, typename A, typename E>
 constexpr auto eval(types::either<A, E> const &input,
-                    NullaryFunction &&fallback) noexcept(noexcept(std::declval<NullaryFunction>()())) -> A {
+                    NullaryFunction &&fallback) noexcept(noexcept(std::invoke(std::declval<NullaryFunction>()))) -> A {
     if (!std::holds_alternative<A>(input)) {
-        return std::forward<NullaryFunction>(fallback)();
+        return std::invoke(std::forward<NullaryFunction>(fallback));
+    } else {
+        return std::get<A>(input);
     }
-    return std::get<A>(input);
 }
 
 }

--- a/include/absent/adapters/either/for_each.h
+++ b/include/absent/adapters/either/for_each.h
@@ -3,6 +3,7 @@
 
 #include "absent/adapters/either/either.h"
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent::adapters::either {
@@ -17,10 +18,10 @@ namespace rvarago::absent::adapters::either {
  */
 template <typename UnaryFunction, typename A, typename E>
 constexpr auto for_each(types::either<A, E> const &input,
-                        UnaryFunction &&action) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> void {
+                        UnaryFunction &&action) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                              std::declval<A>()))) -> void {
     if (auto const p = std::get_if<A>(&input); p) {
-        std::forward<UnaryFunction>(action)(*p);
+        std::invoke(std::forward<UnaryFunction>(action), *p);
     }
 }
 

--- a/include/absent/adapters/either/for_each.h
+++ b/include/absent/adapters/either/for_each.h
@@ -1,9 +1,9 @@
 #ifndef RVARAGO_ABSENT_ADAPTERS_EITHER_FOREACH_H
 #define RVARAGO_ABSENT_ADAPTERS_EITHER_FOREACH_H
 
-#include <utility>
-
 #include "absent/adapters/either/either.h"
+
+#include <utility>
 
 namespace rvarago::absent::adapters::either {
 

--- a/include/absent/adapters/either/transform.h
+++ b/include/absent/adapters/either/transform.h
@@ -1,9 +1,9 @@
 #ifndef RVARAGO_ABSENT_ADAPTERS_EITHER_TRANSFORM_H
 #define RVARAGO_ABSENT_ADAPTERS_EITHER_TRANSFORM_H
 
-#include <utility>
-
 #include "absent/adapters/either/either.h"
+
+#include <utility>
 
 namespace rvarago::absent::adapters::either {
 

--- a/include/absent/and_then.h
+++ b/include/absent/and_then.h
@@ -1,6 +1,7 @@
 #ifndef RVARAGO_ABSENT_ANDTHEN_H
 #define RVARAGO_ABSENT_ANDTHEN_H
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent {
@@ -17,13 +18,15 @@ namespace rvarago::absent {
  */
 template <template <typename> typename Nullable, typename UnaryFunction, typename A>
 constexpr auto and_then(Nullable<A> const &input,
-                        UnaryFunction &&mapper) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> decltype(std::declval<UnaryFunction>()(std::declval<A>())) {
-    using NullableB = decltype(mapper(std::declval<A>()));
+                        UnaryFunction &&mapper) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                              std::declval<A>())))
+    -> decltype(std::invoke(std::declval<UnaryFunction>(), std::declval<A>())) {
+    using NullableB = decltype(std::invoke(mapper, std::declval<A>()));
     if (!input) {
         return NullableB{};
+    } else {
+        return std::invoke(std::forward<UnaryFunction>(mapper), *input);
     }
-    return std::forward<UnaryFunction>(mapper)(*input);
 }
 
 /***
@@ -31,8 +34,9 @@ constexpr auto and_then(Nullable<A> const &input,
  */
 template <template <typename> typename Nullable, typename UnaryFunction, typename A>
 constexpr auto operator>>(Nullable<A> const &input,
-                          UnaryFunction &&mapper) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> decltype(std::declval<UnaryFunction>()(std::declval<A>())) {
+                          UnaryFunction &&mapper) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                                std::declval<A>())))
+    -> decltype(std::invoke(std::declval<UnaryFunction>(), std::declval<A>())) {
     return and_then(input, std::forward<UnaryFunction>(mapper));
 }
 

--- a/include/absent/attempt.h
+++ b/include/absent/attempt.h
@@ -2,6 +2,7 @@
 #define RVARAGO_ABSENT_ATTEMPT_H
 
 #include <exception>
+#include <functional>
 #include <optional>
 #include <utility>
 
@@ -18,10 +19,10 @@ namespace rvarago::absent {
  */
 template <typename BaseException = std::exception, template <typename> typename Nullable = std::optional,
           typename NullaryFunction>
-auto attempt(NullaryFunction &&unsafe) -> Nullable<decltype(std::declval<NullaryFunction>()())> {
-    using NullableA = Nullable<decltype(unsafe())>;
+auto attempt(NullaryFunction &&unsafe) -> Nullable<decltype(std::invoke(std::declval<NullaryFunction>()))> {
+    using NullableA = Nullable<decltype(std::invoke(unsafe))>;
     try {
-        return NullableA{std::forward<NullaryFunction>(unsafe)()};
+        return NullableA{std::invoke(std::forward<NullaryFunction>(unsafe))};
     } catch (BaseException const &) {
         return NullableA{};
     }

--- a/include/absent/eval.h
+++ b/include/absent/eval.h
@@ -1,6 +1,7 @@
 #ifndef RVARAGO_ABSENT_EVAL_H
 #define RVARAGO_ABSENT_EVAL_H
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent {
@@ -16,11 +17,12 @@ namespace rvarago::absent {
  */
 template <template <typename> typename Nullable, typename NullaryFunction, typename A>
 constexpr auto eval(Nullable<A> const &input,
-                    NullaryFunction &&fallback) noexcept(noexcept(std::declval<NullaryFunction>()())) -> A {
+                    NullaryFunction &&fallback) noexcept(noexcept(std::invoke(std::declval<NullaryFunction>()))) -> A {
     if (!input) {
-        return std::forward<NullaryFunction>(fallback)();
+        return std::invoke(std::forward<NullaryFunction>(fallback));
+    } else {
+        return *input;
     }
-    return *input;
 }
 
 }

--- a/include/absent/for_each.h
+++ b/include/absent/for_each.h
@@ -1,6 +1,7 @@
 #ifndef RVARAGO_ABSENT_FOREACH_H
 #define RVARAGO_ABSENT_FOREACH_H
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent {
@@ -15,12 +16,11 @@ namespace rvarago::absent {
  */
 template <template <typename> typename Nullable, typename UnaryFunction, typename A>
 constexpr auto for_each(Nullable<A> const &input,
-                        UnaryFunction &&action) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> void {
-    if (!input) {
-        return;
+                        UnaryFunction &&action) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                              std::declval<A>()))) -> void {
+    if (input) {
+        std::invoke(std::forward<UnaryFunction>(action), *input);
     }
-    std::forward<UnaryFunction>(action)(*input);
 }
 
 }

--- a/include/absent/support/from_variant.h
+++ b/include/absent/support/from_variant.h
@@ -17,12 +17,13 @@ namespace rvarago::absent {
  */
 template <typename A, template <typename> typename Nullable = std::optional, typename... Rest>
 constexpr auto from_variant(std::variant<Rest...> v) noexcept -> Nullable<A> {
-    static_assert(std::disjunction_v<std::is_same<A, Rest>...>, "The provided type A is not a member of the variant.");
+    static_assert(std::disjunction_v<std::is_same<A, Rest>...>, "Type A is not a member type of the variant");
 
     if (auto const value = std::get_if<A>(&v); value) {
         return Nullable<A>{*value};
+    } else {
+        return Nullable<A>{};
     }
-    return Nullable<A>{};
 }
 
 }

--- a/include/absent/support/sink.h
+++ b/include/absent/support/sink.h
@@ -1,6 +1,7 @@
 #ifndef RVARAGO_ABSENT_SUPPORT_SINK_H
 #define RVARAGO_ABSENT_SUPPORT_SINK_H
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent::support {
@@ -12,8 +13,8 @@ namespace rvarago::absent::support {
  * @return a new callable that discards the parameters sent to it.
  */
 template <typename NullaryFunction>
-constexpr auto sink(NullaryFunction &&f) noexcept(noexcept(std::declval<NullaryFunction>()())) {
-    return [f = std::forward<NullaryFunction>(f)](auto &&...) { return std::forward<NullaryFunction>(f)(); };
+constexpr auto sink(NullaryFunction &&f) noexcept(noexcept(std::invoke(std::declval<NullaryFunction>()))) {
+    return [f = std::forward<NullaryFunction>(f)](auto &&...) { return std::invoke(std::forward<NullaryFunction>(f)); };
 }
 
 }

--- a/include/absent/transform.h
+++ b/include/absent/transform.h
@@ -1,6 +1,7 @@
 #ifndef RVARAGO_ABSENT_TRANSFORM_H
 #define RVARAGO_ABSENT_TRANSFORM_H
 
+#include <functional>
 #include <utility>
 
 namespace rvarago::absent {
@@ -16,13 +17,15 @@ namespace rvarago::absent {
  */
 template <template <typename> typename Nullable, typename A, typename UnaryFunction>
 constexpr auto transform(Nullable<A> const &input,
-                         UnaryFunction &&mapper) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> Nullable<decltype(std::declval<UnaryFunction>()(std::declval<A>()))> {
-    using B = decltype(mapper(std::declval<A>()));
+                         UnaryFunction &&mapper) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                               std::declval<A>())))
+    -> Nullable<decltype(std::invoke(std::declval<UnaryFunction>(), std::declval<A>()))> {
+    using B = decltype(std::invoke(mapper, std::declval<A>()));
     if (!input) {
         return Nullable<B>{};
+    } else {
+        return Nullable<B>{std::invoke(std::forward<UnaryFunction>(mapper), *input)};
     }
-    return Nullable<B>{std::forward<UnaryFunction>(mapper)(*input)};
 }
 
 /***
@@ -30,8 +33,9 @@ constexpr auto transform(Nullable<A> const &input,
  */
 template <template <typename> typename Nullable, typename A, typename UnaryFunction>
 constexpr auto operator|(Nullable<A> const &input,
-                         UnaryFunction &&mapper) noexcept(noexcept(std::declval<UnaryFunction>()(std::declval<A>())))
-    -> Nullable<decltype(std::declval<UnaryFunction>()(std::declval<A>()))> {
+                         UnaryFunction &&mapper) noexcept(noexcept(std::invoke(std::declval<UnaryFunction>(),
+                                                                               std::declval<A>())))
+    -> Nullable<decltype(std::invoke(std::declval<UnaryFunction>(), std::declval<A>()))> {
     return transform(input, std::forward<UnaryFunction>(mapper));
 }
 

--- a/tests/and_then_test.cpp
+++ b/tests/and_then_test.cpp
@@ -1,10 +1,10 @@
+#include <absent/and_then.h>
+
 #include <functional>
 #include <optional>
 #include <string>
 
 #include <catch2/catch.hpp>
-
-#include <absent/and_then.h>
 
 using namespace rvarago::absent;
 

--- a/tests/and_then_test.cpp
+++ b/tests/and_then_test.cpp
@@ -1,6 +1,5 @@
 #include <absent/and_then.h>
 
-#include <functional>
 #include <optional>
 #include <string>
 
@@ -50,7 +49,7 @@ SCENARIO("and_then provides a way to and_then {optional<A>, f: A -> optional<B>}
                 std::optional<Person> none;
 
                 THEN("return a new empty optional<string>") {
-                    std::optional<std::string> bound_none = none >> std::mem_fn(&Person::id);
+                    std::optional<std::string> bound_none = none >> &Person::id;
                     CHECK(bound_none == std::nullopt);
                 }
             }
@@ -59,7 +58,7 @@ SCENARIO("and_then provides a way to and_then {optional<A>, f: A -> optional<B>}
                 std::optional<Person> some{Person{}};
 
                 THEN("return a non-empty and bound optional<string>") {
-                    std::optional<std::string> bound_some = some >> std::mem_fn(&Person::id);
+                    std::optional<std::string> bound_some = some >> &Person::id;
                     CHECK(bound_some == std::optional{std::string{"200"}});
                 }
             }

--- a/tests/attempt_test.cpp
+++ b/tests/attempt_test.cpp
@@ -1,9 +1,9 @@
+#include <absent/attempt.h>
+
 #include <optional>
 #include <stdexcept>
 
 #include <catch2/catch.hpp>
-
-#include <absent/attempt.h>
 
 using namespace rvarago::absent;
 

--- a/tests/either/and_then_test.cpp
+++ b/tests/either/and_then_test.cpp
@@ -1,6 +1,5 @@
 #include <absent/adapters/either/and_then.h>
 
-#include <functional>
 #include <string>
 
 #include <catch2/catch.hpp>
@@ -62,7 +61,7 @@ SCENARIO("and_then provides a way to map {either<A, E>, f: A -> either<B, E>} to
                 either<Person, Error> invalid{Error{"404"}};
 
                 THEN("return a new invalid either<string, Error>") {
-                    either<std::string, Error> bound_invalid = invalid >> std::mem_fn(&Person::id);
+                    either<std::string, Error> bound_invalid = invalid >> &Person::id;
                     CHECK(bound_invalid == either<std::string, Error>{Error{"404"}});
                 }
             }
@@ -71,7 +70,7 @@ SCENARIO("and_then provides a way to map {either<A, E>, f: A -> either<B, E>} to
                 either<Person, Error> valid{Person{}};
 
                 THEN("return a valid and bound either<string, Error>>") {
-                    either<std::string, Error> bound_valid = valid >> std::mem_fn(&Person::id);
+                    either<std::string, Error> bound_valid = valid >> &Person::id;
                     CHECK(bound_valid == either<std::string, Error>{std::string{"200"}});
                 }
             }

--- a/tests/either/and_then_test.cpp
+++ b/tests/either/and_then_test.cpp
@@ -1,9 +1,9 @@
+#include <absent/adapters/either/and_then.h>
+
 #include <functional>
 #include <string>
 
 #include <catch2/catch.hpp>
-
-#include <absent/adapters/either/and_then.h>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/attempt_test.cpp
+++ b/tests/either/attempt_test.cpp
@@ -1,8 +1,8 @@
+#include <absent/adapters/either/attempt.h>
+
 #include <stdexcept>
 
 #include <catch2/catch.hpp>
-
-#include <absent/adapters/either/attempt.h>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/eval_test.cpp
+++ b/tests/either/eval_test.cpp
@@ -1,8 +1,8 @@
+#include <absent/adapters/either/eval.h>
+
 #include <optional>
 
 #include <catch2/catch.hpp>
-
-#include <absent/adapters/either/eval.h>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/for_each_test.cpp
+++ b/tests/either/for_each_test.cpp
@@ -1,8 +1,8 @@
+#include <absent/adapters/either/for_each.h>
+
 #include <optional>
 
 #include <catch2/catch.hpp>
-
-#include <absent/adapters/either/for_each.h>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/transform_test.cpp
+++ b/tests/either/transform_test.cpp
@@ -1,6 +1,5 @@
 #include <absent/adapters/either/transform.h>
 
-#include <functional>
 #include <string>
 #include <utility>
 
@@ -61,7 +60,7 @@ SCENARIO("transform provides a way to map {either<A, E>, f: A -> B} to either<B,
                 either<Person, Error> invalid{Error{"404"}};
 
                 THEN("return a new invalid either<string, Error>") {
-                    either<std::string, Error> mapped_invalid = invalid | std::mem_fn(&Person::id);
+                    either<std::string, Error> mapped_invalid = invalid | &Person::id;
                     CHECK(mapped_invalid == either<std::string, Error>{Error{"404"}});
                 }
             }
@@ -70,7 +69,7 @@ SCENARIO("transform provides a way to map {either<A, E>, f: A -> B} to either<B,
                 either<Person, Error> valid{Person{}};
 
                 THEN("return a valid and mapped either<string, Error>") {
-                    either<std::string, Error> mapped_valid = valid | std::mem_fn(&Person::id);
+                    either<std::string, Error> mapped_valid = valid | &Person::id;
                     CHECK(mapped_valid == either<std::string, Error>{std::string{"200"}});
                 }
             }

--- a/tests/either/transform_test.cpp
+++ b/tests/either/transform_test.cpp
@@ -1,10 +1,10 @@
+#include <absent/adapters/either/transform.h>
+
 #include <functional>
 #include <string>
 #include <utility>
 
 #include <catch2/catch.hpp>
-
-#include <absent/adapters/either/transform.h>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/eval_test.cpp
+++ b/tests/eval_test.cpp
@@ -1,8 +1,8 @@
+#include <absent/eval.h>
+
 #include <optional>
 
 #include <catch2/catch.hpp>
-
-#include <absent/eval.h>
 
 using namespace rvarago::absent;
 

--- a/tests/execution_status_test.cpp
+++ b/tests/execution_status_test.cpp
@@ -1,9 +1,9 @@
+#include <absent/and_then.h>
+#include <absent/support/execution_status.h>
+
 #include <string>
 
 #include <catch2/catch.hpp>
-
-#include <absent/and_then.h>
-#include <absent/support/execution_status.h>
 
 using namespace rvarago::absent;
 

--- a/tests/for_each_test.cpp
+++ b/tests/for_each_test.cpp
@@ -1,8 +1,8 @@
+#include <absent/for_each.h>
+
 #include <optional>
 
 #include <catch2/catch.hpp>
-
-#include <absent/for_each.h>
 
 using namespace rvarago::absent;
 

--- a/tests/from_variant_test.cpp
+++ b/tests/from_variant_test.cpp
@@ -1,8 +1,8 @@
+#include <absent/support/from_variant.h>
+
 #include <string>
 
 #include <catch2/catch.hpp>
-
-#include <absent/support/from_variant.h>
 
 using namespace rvarago::absent;
 

--- a/tests/transform_test.cpp
+++ b/tests/transform_test.cpp
@@ -1,10 +1,10 @@
+#include <absent/transform.h>
+
 #include <functional>
 #include <optional>
 #include <string>
 
 #include <catch2/catch.hpp>
-
-#include <absent/transform.h>
 
 using namespace rvarago::absent;
 

--- a/tests/transform_test.cpp
+++ b/tests/transform_test.cpp
@@ -1,6 +1,5 @@
 #include <absent/transform.h>
 
-#include <functional>
 #include <optional>
 #include <string>
 
@@ -50,7 +49,7 @@ SCENARIO("transform provides a way to map {optional<A>, f: A -> B} to optional<B
                 std::optional<Person> none;
 
                 THEN("return a new empty optional<string>") {
-                    std::optional<std::string> mapped_none = none | std::mem_fn(&Person::id);
+                    std::optional<std::string> mapped_none = none | &Person::id;
                     CHECK(mapped_none == std::nullopt);
                 }
             }
@@ -59,7 +58,7 @@ SCENARIO("transform provides a way to map {optional<A>, f: A -> B} to optional<B
                 std::optional<Person> some{Person{}};
 
                 THEN("return a non-empty and mapped optional<string>") {
-                    std::optional<std::string> mapped_some = some | std::mem_fn(&Person::id);
+                    std::optional<std::string> mapped_some = some | &Person::id;
                     CHECK(mapped_some == std::optional{std::string{"200"}});
                 }
             }


### PR DESCRIPTION
By invoking the generic callable with std::invoke, we extend support to member-functions (and variables).