### PR TITLE
Fixes to catch2 includes and macOS build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,13 +21,28 @@ add_executable(${PROJECT_NAME}
         main.cpp
 )
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 target_compile_features(${PROJECT_NAME}
         PRIVATE
             cxx_std_17
 )
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options(${PROJECT_NAME}
+            PRIVATE
+                -std=gnu++17
+    )
+else()
+    target_compile_options(${PROJECT_NAME}
+            PRIVATE
+                -std=c++17
+    )
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(${PROJECT_NAME}
             PRIVATE
                 -Wall -Wextra -Werror -ansi -pedantic
     )

--- a/tests/and_then_test.cpp
+++ b/tests/and_then_test.cpp
@@ -3,7 +3,7 @@
 #include <optional>
 #include <string>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent;
 

--- a/tests/attempt_test.cpp
+++ b/tests/attempt_test.cpp
@@ -3,7 +3,7 @@
 #include <optional>
 #include <stdexcept>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent;
 

--- a/tests/either/and_then_test.cpp
+++ b/tests/either/and_then_test.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/attempt_test.cpp
+++ b/tests/either/attempt_test.cpp
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/eval_test.cpp
+++ b/tests/either/eval_test.cpp
@@ -2,7 +2,7 @@
 
 #include <optional>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/for_each_test.cpp
+++ b/tests/either/for_each_test.cpp
@@ -2,7 +2,7 @@
 
 #include <optional>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/either/transform_test.cpp
+++ b/tests/either/transform_test.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <utility>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent::adapters::either;
 using rvarago::absent::adapters::types::either;

--- a/tests/eval_test.cpp
+++ b/tests/eval_test.cpp
@@ -2,7 +2,7 @@
 
 #include <optional>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent;
 

--- a/tests/execution_status_test.cpp
+++ b/tests/execution_status_test.cpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent;
 

--- a/tests/for_each_test.cpp
+++ b/tests/for_each_test.cpp
@@ -2,7 +2,7 @@
 
 #include <optional>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent;
 

--- a/tests/from_variant_test.cpp
+++ b/tests/from_variant_test.cpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent;
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,2 +1,4 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch_all.hpp>
+
+int main() { return 0; }

--- a/tests/transform_test.cpp
+++ b/tests/transform_test.cpp
@@ -3,7 +3,7 @@
 #include <optional>
 #include <string>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 using namespace rvarago::absent;
 


### PR DESCRIPTION
This PR fixes the following:

1. Wrong catch2 headers: the current version of catch2 does not have `catch2/catch.hpp` (so the build errs out), it should be `catch2/catch_all.hpp`.
2. Missing compiler flag for C++17: there are numerous build errors when those are not passed.
3. Linking on macOS: it currently fails with missing `_main` symbol (at least for some macOS versions). Fixed.